### PR TITLE
Fix small missmatch between 1.11.2 and 1.12.2

### DIFF
--- a/mappings/1.12.2.tiny
+++ b/mappings/1.12.2.tiny
@@ -22060,7 +22060,7 @@ CLASS	lz	net/minecraft/class_2593
 FIELD	lz	Ljava/util/UUID;	a	field_11733
 METHOD	lz	(Lkx;)V	a	method_10730
 METHOD	lz	(Loo;)Lvg;	a	method_10731
-CLASS	m	net/minecraft/class_815
+CLASS	m	net/minecraft/class_3344
 FIELD	m	Lbe;	A	field_16326
 FIELD	m	Lav;	B	field_16327
 FIELD	m	Ljava/util/Map;	C	field_16328
@@ -22232,7 +22232,7 @@ METHOD	mz	(I)Lmy;	a	method_12715
 METHOD	mz	(Lgy;)Ljava/lang/Object;	a	method_12716
 METHOD	mz	(Lgy;Ljava/lang/Object;)V	a	method_12717
 METHOD	mz	(Ljava/lang/Object;)Ljava/lang/Object;	a	method_14878
-CLASS	n	net/minecraft/class_3344
+CLASS	n	net/minecraft/class_3345
 FIELD	n	Lq;	a	field_16355
 METHOD	n	()Lq;	a	method_14879
 METHOD	n	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Ln;	a	method_14880
@@ -22353,7 +22353,7 @@ METHOD	nb$a	(Z)V	a	method_2709
 METHOD	nb$a	()Ljava/lang/Object;	b	method_2710
 METHOD	nb$a	()Z	c	method_2712
 METHOD	nb$a	()Lnb$a;	d	method_14902
-CLASS	ne	net/minecraft/class_3345
+CLASS	ne	net/minecraft/class_3346
 FIELD	ne	Lorg/apache/logging/log4j/Logger;	a	field_16357
 FIELD	ne	Laef;	b	field_16358
 FIELD	ne	Loq;	c	field_16359
@@ -22962,7 +22962,7 @@ METHOD	nf	(Ljava/lang/Object;)I	compareTo	compareTo
 METHOD	nf	(Ljava/lang/Object;)Z	equals	equals
 METHOD	nf	()I	hashCode	hashCode
 METHOD	nf	()Ljava/lang/String;	toString	toString
-CLASS	nf$a	net/minecraft/class_1653$class_3346
+CLASS	nf$a	net/minecraft/class_1653$class_3347
 METHOD	nf$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnf;	a	method_14915
 METHOD	nf$a	(Lnf;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;	a	method_14916
 METHOD	nf$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
@@ -23046,7 +23046,7 @@ FIELD	no	Ljava/lang/String;	b	field_11750
 METHOD	no	(Ljava/lang/String;)V	a	method_10742
 METHOD	no	(Ljava/lang/Object;)V	println	println
 METHOD	no	(Ljava/lang/String;)V	println	println
-CLASS	np	net/minecraft/class_3347
+CLASS	np	net/minecraft/class_3348
 FIELD	np	Lorg/apache/logging/log4j/Logger;	a	field_16366
 FIELD	np	Lcom/google/gson/Gson;	b	field_16367
 FIELD	np	Lcom/google/gson/reflect/TypeToken;	c	field_16368
@@ -23078,11 +23078,11 @@ METHOD	np	()V	f	method_14932
 METHOD	np	(Li;)Z	f	method_14933
 METHOD	np	()V	g	method_14934
 METHOD	np	(Li;)Z	g	method_14935
-CLASS	np$1	net/minecraft/class_3347$1
+CLASS	np$1	net/minecraft/class_3348$1
 CLASS	nr	net/minecraft/class_2596
 FIELD	nr	Lnr;	a	field_11751
 METHOD	nr	()Ljava/lang/Throwable;	fillInStackTrace	fillInStackTrace
-CLASS	ns	net/minecraft/class_3348
+CLASS	ns	net/minecraft/class_3349
 FIELD	ns	Lorg/apache/logging/log4j/Logger;	a	field_16378
 FIELD	ns	Lcom/google/gson/Gson;	b	field_16379
 FIELD	ns	Lj;	c	field_16380
@@ -23094,10 +23094,10 @@ METHOD	ns	(Lnf;)Li;	a	method_14938
 METHOD	ns	()Z	b	method_14939
 METHOD	ns	()Ljava/lang/Iterable;	c	method_14940
 METHOD	ns	()Ljava/util/Map;	d	method_14941
-CLASS	ns$1	net/minecraft/class_3348$1
+CLASS	ns$1	net/minecraft/class_3349$1
 METHOD	ns$1	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Li$a;	a	method_14942
 METHOD	ns$1	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
-CLASS	nt	net/minecraft/class_3349
+CLASS	nt	net/minecraft/class_3350
 FIELD	nt	Lorg/apache/logging/log4j/Logger;	a	field_16383
 FIELD	nt	Ljava/io/File;	b	field_16384
 FIELD	nt	Lnet/minecraft/server/MinecraftServer;	c	field_16385
@@ -23116,9 +23116,9 @@ METHOD	nt	()I	c	method_14948
 METHOD	nt	()Ljava/util/Map;	d	method_14949
 METHOD	nt	()V	f	method_14950
 METHOD	nt	()V	h	method_14951
-CLASS	nt$1	net/minecraft/class_3349$1
+CLASS	nt$1	net/minecraft/class_3350$1
 FIELD	nt$1	Lnt;	a	field_16392
-CLASS	nt$a	net/minecraft/class_3349$class_3350
+CLASS	nt$a	net/minecraft/class_3350$class_3351
 FIELD	nt$a	Lnt;	a	field_16393
 FIELD	nt$a	Lbn;	b	field_16394
 FIELD	nt$a	Lbm$c;	c	field_16395
@@ -23219,7 +23219,7 @@ CLASS	nz$4	net/minecraft/class_770$4
 FIELD	nz$4	Lnz;	a	field_5299
 METHOD	nz$4	()Ljava/lang/String;	a	method_4406
 METHOD	nz$4	()Ljava/lang/Object;	call	call
-CLASS	o	net/minecraft/class_3351
+CLASS	o	net/minecraft/class_3352
 FIELD	o	Ljava/text/SimpleDateFormat;	a	field_16396
 FIELD	o	Lk;	b	field_16397
 FIELD	o	Ljava/util/Date;	c	field_16398
@@ -23697,13 +23697,13 @@ FIELD	oz$7	Lgw;	a	field_11773
 FIELD	oz$7	Lho;	b	field_11774
 FIELD	oz$7	Loz;	c	field_11775
 METHOD	oz$7	(Lio/netty/util/concurrent/Future;)V	operationComplete	operationComplete
-CLASS	p	net/minecraft/class_3352
+CLASS	p	net/minecraft/class_3353
 METHOD	p	()Lnf;	a	method_14970
 METHOD	p	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lq;	a	method_14971
 METHOD	p	(Lnp;)V	a	method_14972
 METHOD	p	(Lnp;Lp$a;)V	a	method_14973
 METHOD	p	(Lnp;Lp$a;)V	b	method_14974
-CLASS	p$a	net/minecraft/class_3352$class_3353
+CLASS	p$a	net/minecraft/class_3353$class_3354
 FIELD	p$a	Lq;	a	field_16406
 FIELD	p$a	Li;	b	field_16407
 FIELD	p$a	Ljava/lang/String;	c	field_16408
@@ -24133,7 +24133,7 @@ METHOD	pz	(Ljava/lang/String;)V	c	method_2229
 METHOD	pz	()I	d	method_2230
 METHOD	pz	(Ljava/lang/String;)V	d	method_2231
 METHOD	pz	()V	e	method_2232
-CLASS	q	net/minecraft/class_3354
+CLASS	q	net/minecraft/class_3355
 METHOD	q	()Lnf;	a	method_14981
 CLASS	qa	net/minecraft/class_810
 FIELD	qa	J	h	field_2935
@@ -24775,7 +24775,7 @@ CLASS	qj	net/minecraft/class_817
 CLASS	qk	net/minecraft/class_818
 FIELD	qk	Lain;	g	field_9030
 METHOD	qk	()Lain;	b	method_2260
-CLASS	ql	net/minecraft/class_3355
+CLASS	ql	net/minecraft/class_3356
 FIELD	ql	Ljava/util/BitSet;	a	field_16469
 FIELD	ql	Ljava/util/BitSet;	b	field_16470
 FIELD	ql	Z	c	field_16471
@@ -24792,7 +24792,7 @@ METHOD	ql	(Lakt;)I	d	method_14990
 METHOD	ql	(Lakt;)Z	e	method_14991
 METHOD	ql	(Lakt;)V	f	method_14992
 METHOD	ql	(Lakt;)V	g	method_14993
-CLASS	qm	net/minecraft/class_3356
+CLASS	qm	net/minecraft/class_3357
 FIELD	qm	Lorg/apache/logging/log4j/Logger;	e	field_16473
 METHOD	qm	(Lfy;)V	a	method_14994
 METHOD	qm	(Ljava/util/List;Loq;)V	a	method_14995
@@ -24989,7 +24989,7 @@ METHOD	qz	(I)V	d	method_12865
 METHOD	qz	(Ljava/lang/Object;)I	d	method_12866
 METHOD	qz	(I)I	e	method_12867
 METHOD	qz	()Ljava/util/Iterator;	iterator	iterator
-CLASS	r	net/minecraft/class_3357
+CLASS	r	net/minecraft/class_3358
 FIELD	r	Lhh;	a	field_16474
 FIELD	r	Lhh;	b	field_16475
 FIELD	r	Laip;	c	field_16476
@@ -25305,7 +25305,7 @@ METHOD	rz	()Lry;	a	method_12906
 METHOD	rz	(Lrx;Lfy;ILjava/lang/String;)Lfy;	a	method_12907
 METHOD	rz	(Lry;)V	a	method_12908
 METHOD	rz	(Lrx;Lfy;ILjava/lang/String;)Lfy;	b	method_12909
-CLASS	s	net/minecraft/class_3358
+CLASS	s	net/minecraft/class_3359
 FIELD	s	Ls;	a	field_16484
 FIELD	s	Ls;	b	field_16485
 FIELD	s	Ls;	c	field_16486
@@ -25321,9 +25321,9 @@ METHOD	s	(Ljava/lang/String;)Ls;	valueOf	valueOf
 METHOD	s	()[Ls;	values	values
 CLASS	sa	net/minecraft/class_2936
 METHOD	sa	(Lrx;Lfy;I)Lfy;	a	method_12910
-CLASS	sb	net/minecraft/class_3359
+CLASS	sb	net/minecraft/class_3360
 FIELD	sb	Lorg/apache/logging/log4j/Logger;	a	field_16491
-CLASS	sc	net/minecraft/class_3360
+CLASS	sc	net/minecraft/class_3361
 CLASS	sd	net/minecraft/class_3118
 FIELD	sd	Ljava/util/Map;	a	field_15435
 CLASS	se	net/minecraft/class_2948
@@ -25362,7 +25362,7 @@ CLASS	sy	net/minecraft/class_3031
 FIELD	sy	Lnf;	a	field_15024
 CLASS	sz	net/minecraft/class_2945
 FIELD	sz	[Ljava/lang/String;	a	field_14402
-CLASS	t	net/minecraft/class_3361
+CLASS	t	net/minecraft/class_3362
 FIELD	t	Li;	a	field_16492
 FIELD	t	Lt;	b	field_16493
 FIELD	t	Lt;	c	field_16494
@@ -25509,7 +25509,7 @@ METHOD	tz	(I)Ltz;	a	method_8351
 METHOD	tz	()Ljava/lang/String;	b	method_8352
 METHOD	tz	(Ljava/lang/String;)Ltz;	valueOf	valueOf
 METHOD	tz	()[Ltz;	values	values
-CLASS	u	net/minecraft/class_3362
+CLASS	u	net/minecraft/class_3363
 FIELD	u	Lnf;	a	field_16504
 METHOD	u	()Ljava/lang/String;	toString	toString
 CLASS	ua	net/minecraft/class_2607
@@ -25752,20 +25752,20 @@ METHOD	uz	()Ljava/util/Map;	h	method_6092
 METHOD	uz	()Z	i	method_2448
 METHOD	uz	()Luz;	j	method_12944
 METHOD	uz	()V	k	method_12945
-CLASS	v	net/minecraft/class_3363
+CLASS	v	net/minecraft/class_3364
 FIELD	v	Lnf;	a	field_16505
 FIELD	v	Ljava/util/Map;	b	field_16506
 METHOD	v	(Loq;Lzv;Lzv;Lvd;)V	a	method_15041
 METHOD	v	()Lnf;	b	method_15042
 METHOD	v	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lv$b;	b	method_15043
-CLASS	v$a	net/minecraft/class_3363$class_3364
+CLASS	v$a	net/minecraft/class_3364$class_3365
 FIELD	v$a	Lnp;	a	field_16507
 FIELD	v$a	Ljava/util/Set;	b	field_16508
 METHOD	v$a	()Z	a	method_15044
 METHOD	v$a	(Loq;Lzv;Lzv;Lvd;)V	a	method_15045
 METHOD	v$a	(Lp$a;)V	a	method_15046
 METHOD	v$a	(Lp$a;)V	b	method_15047
-CLASS	v$b	net/minecraft/class_3363$class_3365
+CLASS	v$b	net/minecraft/class_3364$class_3366
 FIELD	v$b	Laj;	a	field_16509
 FIELD	v$b	Laj;	b	field_16510
 FIELD	v$b	Laj;	c	field_16511
@@ -26703,20 +26703,20 @@ METHOD	vz	()Z	a	method_13089
 METHOD	vz	(I)V	a_	method_6299
 METHOD	vz	(I)V	b_	method_13090
 METHOD	vz	()V	r_	method_13091
-CLASS	w	net/minecraft/class_3366
+CLASS	w	net/minecraft/class_3367
 FIELD	w	Lnf;	a	field_16514
 FIELD	w	Ljava/util/Map;	b	field_16515
 METHOD	w	(Loq;Lakg;)V	a	method_15062
 METHOD	w	()Lnf;	b	method_15063
 METHOD	w	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lw$b;	b	method_15064
-CLASS	w$a	net/minecraft/class_3366$class_3367
+CLASS	w$a	net/minecraft/class_3367$class_3368
 FIELD	w$a	Lnp;	a	field_16516
 FIELD	w$a	Ljava/util/Set;	b	field_16517
 METHOD	w$a	()Z	a	method_15065
 METHOD	w$a	(Lakg;)V	a	method_15066
 METHOD	w$a	(Lp$a;)V	a	method_15067
 METHOD	w$a	(Lp$a;)V	b	method_15068
-CLASS	w$b	net/minecraft/class_3366$class_3368
+CLASS	w$b	net/minecraft/class_3367$class_3369
 FIELD	w$b	Lakg;	a	field_16518
 METHOD	w$b	(Lakg;)Z	a	method_15069
 CLASS	wb	net/minecraft/class_880
@@ -26820,7 +26820,7 @@ FIELD	wl	I	b	field_3429
 FIELD	wl	F	c	field_3430
 METHOD	wl	()V	a	method_2722
 METHOD	wl	(FFF)F	a	method_2723
-CLASS	wn	net/minecraft/class_3369
+CLASS	wn	net/minecraft/class_3370
 CLASS	wo	net/minecraft/class_882
 FIELD	wo	Z	a	field_3432
 FIELD	wo	Lvq;	b	field_3431
@@ -26927,24 +26927,24 @@ FIELD	wy	Lamu;	f	field_3490
 METHOD	wy	()Lbhe;	f	method_2741
 CLASS	wz	net/minecraft/class_893
 FIELD	wz	Lvq;	a	field_3491
-CLASS	x	net/minecraft/class_3370
+CLASS	x	net/minecraft/class_3371
 FIELD	x	Lnf;	a	field_16519
 FIELD	x	Ljava/util/Map;	b	field_16520
 METHOD	x	(Loq;Layn;Layn;)V	a	method_15071
 METHOD	x	()Lnf;	b	method_15072
 METHOD	x	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lx$b;	b	method_15073
-CLASS	x$a	net/minecraft/class_3370$class_3371
+CLASS	x$a	net/minecraft/class_3371$class_3372
 FIELD	x$a	Lnp;	a	field_16521
 FIELD	x$a	Ljava/util/Set;	b	field_16522
 METHOD	x$a	()Z	a	method_15074
 METHOD	x$a	(Layn;Layn;)V	a	method_15075
 METHOD	x$a	(Lp$a;)V	a	method_15076
 METHOD	x$a	(Lp$a;)V	b	method_15077
-CLASS	x$b	net/minecraft/class_3370$class_3372
+CLASS	x$b	net/minecraft/class_3371$class_3373
 FIELD	x$b	Layn;	a	field_16523
 FIELD	x$b	Layn;	b	field_16524
 METHOD	x$b	(Layn;Layn;)Z	a	method_15078
-CLASS	xa	net/minecraft/class_3373
+CLASS	xa	net/minecraft/class_3374
 FIELD	xa	Lvq;	a	field_16525
 FIELD	xa	Lcom/google/common/base/Predicate;	b	field_16526
 FIELD	xa	Lvq;	c	field_16527
@@ -26954,12 +26954,12 @@ FIELD	xa	I	f	field_16530
 FIELD	xa	F	g	field_16531
 FIELD	xa	F	h	field_16532
 FIELD	xa	F	i	field_16533
-CLASS	xa$1	net/minecraft/class_3373$1
+CLASS	xa$1	net/minecraft/class_3374$1
 FIELD	xa$1	Lvq;	a	field_16534
 FIELD	xa$1	Lxa;	b	field_16535
 METHOD	xa$1	(Lvq;)Z	a	method_15079
 METHOD	xa$1	(Ljava/lang/Object;)Z	apply	apply
-CLASS	xb	net/minecraft/class_3374
+CLASS	xb	net/minecraft/class_3375
 CLASS	xc	net/minecraft/class_894
 FIELD	xc	Lamu;	a	field_3492
 FIELD	xc	F	b	field_3493
@@ -27017,7 +27017,7 @@ FIELD	xg	Z	d	field_11934
 FIELD	xg	Z	e	field_11935
 FIELD	xg	I	f	field_11936
 CLASS	xh	net/minecraft/class_899
-CLASS	xi	net/minecraft/class_3375
+CLASS	xi	net/minecraft/class_3376
 FIELD	xi	Laah;	a	field_16536
 FIELD	xi	Laed;	b	field_16537
 FIELD	xi	Z	c	field_16538
@@ -27129,20 +27129,20 @@ FIELD	xz	Lady;	a	field_3584
 FIELD	xz	Lvp;	b	field_6854
 FIELD	xz	D	c	field_6855
 FIELD	xz	I	d	field_3587
-CLASS	y	net/minecraft/class_3376
+CLASS	y	net/minecraft/class_3377
 FIELD	y	Lnf;	a	field_16539
 FIELD	y	Ljava/util/Map;	b	field_16540
 METHOD	y	(Loq;Lavh;)V	a	method_15081
 METHOD	y	()Lnf;	b	method_15082
 METHOD	y	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Ly$b;	b	method_15083
-CLASS	y$a	net/minecraft/class_3376$class_3377
+CLASS	y$a	net/minecraft/class_3377$class_3378
 FIELD	y$a	Lnp;	a	field_16541
 FIELD	y$a	Ljava/util/Set;	b	field_16542
 METHOD	y$a	()Z	a	method_15084
 METHOD	y$a	(Lavh;)V	a	method_15085
 METHOD	y$a	(Lp$a;)V	a	method_15086
 METHOD	y$a	(Lp$a;)V	b	method_15087
-CLASS	y$b	net/minecraft/class_3376$class_3378
+CLASS	y$b	net/minecraft/class_3377$class_3379
 FIELD	y$b	Las;	a	field_16543
 METHOD	y$b	(Lavh;)Z	a	method_15088
 CLASS	yb	net/minecraft/class_916
@@ -27227,7 +27227,7 @@ FIELD	ym	Lady;	a	field_3621
 CLASS	yn	net/minecraft/class_2617
 FIELD	yn	I	e	field_11947
 FIELD	yn	Lady;	f	field_11948
-CLASS	yo	net/minecraft/class_3379
+CLASS	yo	net/minecraft/class_3380
 METHOD	yo	()Lbhe;	j	method_15089
 CLASS	yp	net/minecraft/class_3133
 FIELD	yp	F	h	field_15483
@@ -27298,20 +27298,20 @@ CLASS	yz	net/minecraft/class_932
 FIELD	yz	Lwb;	a	field_3635
 FIELD	yz	Lvp;	b	field_6873
 FIELD	yz	I	c	field_6874
-CLASS	z	net/minecraft/class_3380
+CLASS	z	net/minecraft/class_3381
 FIELD	z	Lnf;	a	field_16545
 FIELD	z	Ljava/util/Map;	b	field_16546
 METHOD	z	(Loq;Laip;)V	a	method_15090
 METHOD	z	()Lnf;	b	method_15091
 METHOD	z	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lz$b;	b	method_15092
-CLASS	z$a	net/minecraft/class_3380$class_3381
+CLASS	z$a	net/minecraft/class_3381$class_3382
 FIELD	z$a	Lnp;	a	field_16547
 FIELD	z$a	Ljava/util/Set;	b	field_16548
 METHOD	z$a	()Z	a	method_15093
 METHOD	z$a	(Laip;)V	a	method_15094
 METHOD	z$a	(Lp$a;)V	a	method_15095
 METHOD	z$a	(Lp$a;)V	b	method_15096
-CLASS	z$b	net/minecraft/class_3380$class_3382
+CLASS	z$b	net/minecraft/class_3381$class_3383
 FIELD	z$b	Lan;	a	field_16549
 METHOD	z$b	(Laip;)Z	a	method_15097
 CLASS	za	net/minecraft/class_933
@@ -27328,7 +27328,7 @@ METHOD	za	(Lvp;Z)Z	a	method_6221
 METHOD	za	(Lvq;Lvp;ZZ)Z	a	method_11025
 METHOD	za	(I)Lza;	b	method_13955
 METHOD	za	()D	i	method_6222
-CLASS	zc	net/minecraft/class_3383
+CLASS	zc	net/minecraft/class_3384
 METHOD	zc	(Z)V	a	method_15098
 METHOD	zc	(Z)V	b	method_15099
 METHOD	zc	(Z)V	c	method_15100
@@ -27554,8 +27554,8 @@ METHOD	zw	(Z)V	p	method_8388
 CLASS	zx	net/minecraft/class_944
 METHOD	zx	(Lry;)V	a	method_13501
 METHOD	zx	(Lvd;)Lzx;	b	method_4517
-CLASS	zy	net/minecraft/class_3384
+CLASS	zy	net/minecraft/class_3385
 CLASS	zz	net/minecraft/class_945
 # INTERMEDIARY-COUNTER field 16551
 # INTERMEDIARY-COUNTER method 15104
-# INTERMEDIARY-COUNTER class 3385
+# INTERMEDIARY-COUNTER class 3386

--- a/mappings/1.13.2.tiny
+++ b/mappings/1.13.2.tiny
@@ -49,20 +49,20 @@ METHOD	a	()Ljava/lang/String;	g	method_4708
 METHOD	a	()Ljava/lang/String;	toString	toString
 METHOD	a	(Ljava/lang/String;)La;	valueOf	valueOf
 METHOD	a	()[La;	values	values
-CLASS	aa	net/minecraft/class_3366
+CLASS	aa	net/minecraft/class_3367
 FIELD	aa	Lpc;	a	field_16514
 FIELD	aa	Ljava/util/Map;	b	field_16515
 METHOD	aa	(Ltf;Laut;)V	a	method_15062
 METHOD	aa	()Lpc;	b	method_15063
 METHOD	aa	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Laa$b;	b	method_15064
-CLASS	aa$a	net/minecraft/class_3366$class_3367
+CLASS	aa$a	net/minecraft/class_3367$class_3368
 FIELD	aa$a	Lpm;	a	field_16516
 FIELD	aa$a	Ljava/util/Set;	b	field_16517
 METHOD	aa$a	()Z	a	method_15065
 METHOD	aa$a	(Laut;)V	a	method_15066
 METHOD	aa$a	(Ls$a;)V	a	method_15067
 METHOD	aa$a	(Ls$a;)V	b	method_15068
-CLASS	aa$b	net/minecraft/class_3366$class_3368
+CLASS	aa$b	net/minecraft/class_3367$class_3369
 FIELD	aa$b	Laut;	a	field_16518
 METHOD	aa$b	(Laut;)Z	a	method_15069
 METHOD	aa$b	()Laa$b;	c	method_15110
@@ -71,14 +71,14 @@ FIELD	aaa	[Ljava/lang/String;	a	field_14404
 METHOD	aaa	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15111
 METHOD	aaa	([Ljava/lang/String;)V	a	method_15112
 METHOD	aaa	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aab	net/minecraft/class_3385
+CLASS	aab	net/minecraft/class_3386
 FIELD	aab	Ljava/lang/String;	a	field_16552
 METHOD	aab	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Ljava/util/function/Function;)Lcom/mojang/datafixers/DataFix;	a	method_15113
 METHOD	aab	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15114
 METHOD	aab	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15115
 METHOD	aab	(Ljava/lang/String;)Ljava/lang/String;	a	method_15116
 METHOD	aab	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aab$1	net/minecraft/class_3385$1
+CLASS	aab$1	net/minecraft/class_3386$1
 FIELD	aab$1	Ljava/util/function/Function;	a	field_16553
 CLASS	aac	net/minecraft/class_3127
 FIELD	aac	[Ljava/lang/String;	a	field_15437
@@ -93,7 +93,7 @@ METHOD	aad	([Ljava/lang/String;)V	a	method_15121
 METHOD	aad	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Ljava/util/Optional;	b	method_15122
 METHOD	aad	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Ljava/util/Optional;	c	method_15123
 METHOD	aad	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aae	net/minecraft/class_3386
+CLASS	aae	net/minecraft/class_3387
 FIELD	aae	Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;	a	field_16554
 METHOD	aae	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15124
 METHOD	aae	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15125
@@ -105,15 +105,15 @@ METHOD	aae	(Ljava/util/stream/Stream;)Ljava/util/stream/Stream;	b	method_15130
 METHOD	aae	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	c	method_15131
 METHOD	aae	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	d	method_15132
 METHOD	aae	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aaf	net/minecraft/class_3387
+CLASS	aaf	net/minecraft/class_3388
 METHOD	aaf	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15133
 METHOD	aaf	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aag	net/minecraft/class_3388
+CLASS	aag	net/minecraft/class_3389
 FIELD	aag	Ljava/util/Map;	a	field_16555
 METHOD	aag	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15134
 METHOD	aag	(Ljava/util/HashMap;)V	a	method_15135
 METHOD	aag	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aah	net/minecraft/class_3389
+CLASS	aah	net/minecraft/class_3390
 FIELD	aah	Ljava/util/Map;	a	field_16556
 FIELD	aah	Ljava/util/Set;	b	field_16557
 FIELD	aah	Ljava/util/Set;	c	field_16558
@@ -133,7 +133,7 @@ METHOD	aaj	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method
 METHOD	aaj	(Ljava/util/stream/Stream;)Ljava/util/stream/Stream;	a	method_15145
 METHOD	aaj	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	b	method_15146
 METHOD	aaj	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aak	net/minecraft/class_3390
+CLASS	aak	net/minecraft/class_3391
 FIELD	aak	[[I	a	field_16559
 FIELD	aak	Lit/unimi/dsi/fastutil/objects/Object2IntMap;	b	field_16560
 FIELD	aak	Ljava/util/Set;	c	field_16561
@@ -153,7 +153,7 @@ METHOD	aak	()Ljava/util/Set;	b	method_15159
 METHOD	aak	(I)I	b	method_15160
 METHOD	aak	(I)I	c	method_15161
 METHOD	aak	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aak$a	net/minecraft/class_3390$class_3391
+CLASS	aak$a	net/minecraft/class_3391$class_3392
 FIELD	aak$a	Lit/unimi/dsi/fastutil/ints/IntSet;	f	field_16562
 FIELD	aak$a	Lit/unimi/dsi/fastutil/ints/IntSet;	g	field_16563
 FIELD	aak$a	Lit/unimi/dsi/fastutil/ints/Int2IntMap;	h	field_16564
@@ -167,7 +167,7 @@ METHOD	aak$a	(Lcom/mojang/datafixers/Dynamic;)Ljava/util/Optional;	b	method_1516
 METHOD	aak$a	(Lcom/mojang/datafixers/Dynamic;)Ljava/util/Optional;	c	method_15169
 METHOD	aak$a	(I)I	d	method_15170
 METHOD	aak$a	(Lcom/mojang/datafixers/Dynamic;)Ljava/util/Optional;	d	method_15171
-CLASS	aak$b	net/minecraft/class_3390$class_3392
+CLASS	aak$b	net/minecraft/class_3391$class_3393
 FIELD	aak$b	Lcom/mojang/datafixers/types/Type;	a	field_16565
 FIELD	aak$b	Lcom/mojang/datafixers/OpticFinder;	b	field_16566
 FIELD	aak$b	Ljava/util/List;	c	field_16567
@@ -183,7 +183,7 @@ METHOD	aak$b	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/util/Pair;	
 METHOD	aak$b	()I	c	method_15179
 METHOD	aak$b	(I)I	c	method_15180
 METHOD	aak$b	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	c	method_15181
-CLASS	aal	net/minecraft/class_3393
+CLASS	aal	net/minecraft/class_3394
 FIELD	aal	Ljava/util/Map;	a	field_16570
 METHOD	aal	()Ljava/lang/IllegalStateException;	a	method_15182
 METHOD	aal	(Lcom/mojang/datafixers/types/DynamicOps;Lcom/mojang/datafixers/util/Pair;)Ljava/lang/Object;	a	method_15183
@@ -195,7 +195,7 @@ METHOD	aal	(Ljava/util/HashMap;)V	a	method_15188
 METHOD	aal	(Lcom/mojang/datafixers/types/DynamicOps;Ljava/util/Map$Entry;)Lcom/mojang/datafixers/util/Pair;	b	method_15189
 METHOD	aal	(Ljava/lang/String;)Ljava/util/List;	b	method_15190
 METHOD	aal	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aam	net/minecraft/class_3394
+CLASS	aam	net/minecraft/class_3395
 FIELD	aam	Lcom/google/common/base/Splitter;	a	field_16571
 FIELD	aam	Lcom/google/common/base/Splitter;	b	field_16572
 FIELD	aam	Lcom/google/common/base/Splitter;	c	field_16573
@@ -212,21 +212,21 @@ METHOD	aan	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	me
 METHOD	aan	(Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15197
 METHOD	aan	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	b	method_15198
 METHOD	aan	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aao	net/minecraft/class_3395
+CLASS	aao	net/minecraft/class_3396
 FIELD	aao	Ljava/lang/String;	a	field_16576
 FIELD	aao	Ljava/lang/String;	b	field_16577
 FIELD	aao	Lcom/mojang/datafixers/DSL$TypeReference;	c	field_16578
 METHOD	aao	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15199
 METHOD	aao	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15200
 METHOD	aao	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aap	net/minecraft/class_3396
+CLASS	aap	net/minecraft/class_3397
 METHOD	aap	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15201
 METHOD	aap	(Lcom/mojang/datafixers/Dynamic;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15202
 METHOD	aap	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15203
 METHOD	aap	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15204
 METHOD	aap	(Ljava/lang/String;)Ljava/lang/String;	a	method_15205
 METHOD	aap	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aaq	net/minecraft/class_3397
+CLASS	aaq	net/minecraft/class_3398
 METHOD	aaq	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15206
 METHOD	aaq	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15207
 METHOD	aaq	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15208
@@ -236,7 +236,7 @@ CLASS	aar	net/minecraft/class_3032
 METHOD	aar	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15210
 METHOD	aar	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15211
 METHOD	aar	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aas	net/minecraft/class_3398
+CLASS	aas	net/minecraft/class_3399
 FIELD	aas	Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;	a	field_16579
 METHOD	aas	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15212
 METHOD	aas	(Lcom/mojang/datafixers/Dynamic;Ljava/util/Map;)Lcom/mojang/datafixers/Dynamic;	a	method_15213
@@ -244,7 +244,7 @@ METHOD	aas	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method
 METHOD	aas	(Lit/unimi/dsi/fastutil/ints/Int2ObjectOpenHashMap;)V	a	method_15215
 METHOD	aas	(Ljava/util/Map$Entry;)Lcom/mojang/datafixers/util/Pair;	a	method_15216
 METHOD	aas	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aat	net/minecraft/class_3399
+CLASS	aat	net/minecraft/class_3400
 METHOD	aat	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15217
 METHOD	aat	(Lcom/mojang/datafixers/Dynamic;Ljava/util/Map$Entry;)Lcom/mojang/datafixers/util/Pair;	a	method_15218
 METHOD	aat	(Lcom/mojang/datafixers/Dynamic;Ljava/util/Map;)Lcom/mojang/datafixers/Dynamic;	a	method_15219
@@ -254,19 +254,19 @@ CLASS	aau	net/minecraft/class_3130
 METHOD	aau	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15221
 METHOD	aau	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15222
 METHOD	aau	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aav	net/minecraft/class_3400
+CLASS	aav	net/minecraft/class_3401
 FIELD	aav	Ljava/util/Map;	a	field_16580
 METHOD	aav	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15223
 METHOD	aav	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15224
 METHOD	aav	(Ljava/lang/String;)Ljava/lang/String;	a	method_15225
 METHOD	aav	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aaw	net/minecraft/class_3401
+CLASS	aaw	net/minecraft/class_3402
 FIELD	aaw	Ljava/util/Map;	a	field_16581
 METHOD	aaw	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15226
 METHOD	aaw	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15227
 METHOD	aaw	(Ljava/lang/String;)Ljava/lang/String;	a	method_15228
 METHOD	aaw	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	aax	net/minecraft/class_3402
+CLASS	aax	net/minecraft/class_3403
 FIELD	aax	Lcom/mojang/datafixers/DSL$TypeReference;	a	field_16582
 FIELD	aax	Lcom/mojang/datafixers/DSL$TypeReference;	b	field_16583
 FIELD	aax	Lcom/mojang/datafixers/DSL$TypeReference;	c	field_16584
@@ -304,29 +304,29 @@ METHOD	aax	()Ljava/lang/String;	k	method_15239
 METHOD	aax	()Ljava/lang/String;	l	method_15240
 METHOD	aax	()Ljava/lang/String;	m	method_15241
 METHOD	aax	()Ljava/lang/String;	n	method_15242
-CLASS	aay	net/minecraft/class_3403
+CLASS	aay	net/minecraft/class_3404
 FIELD	aay	Ljava/util/Map;	a	field_16605
-CLASS	aaz	net/minecraft/class_3404
+CLASS	aaz	net/minecraft/class_3405
 FIELD	aaz	Ljava/util/Map;	a	field_16606
-CLASS	ab	net/minecraft/class_3370
+CLASS	ab	net/minecraft/class_3371
 FIELD	ab	Lpc;	a	field_16519
 FIELD	ab	Ljava/util/Map;	b	field_16520
 METHOD	ab	(Ltf;Lbod;Lbod;)V	a	method_15071
 METHOD	ab	()Lpc;	b	method_15072
 METHOD	ab	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lab$b;	b	method_15073
-CLASS	ab$a	net/minecraft/class_3370$class_3371
+CLASS	ab$a	net/minecraft/class_3371$class_3372
 FIELD	ab$a	Lpm;	a	field_16521
 FIELD	ab$a	Ljava/util/Set;	b	field_16522
 METHOD	ab$a	()Z	a	method_15074
 METHOD	ab$a	(Lbod;Lbod;)V	a	method_15075
 METHOD	ab$a	(Ls$a;)V	a	method_15076
 METHOD	ab$a	(Ls$a;)V	b	method_15077
-CLASS	ab$b	net/minecraft/class_3370$class_3372
+CLASS	ab$b	net/minecraft/class_3371$class_3373
 FIELD	ab$b	Lbod;	a	field_16523
 FIELD	ab$b	Lbod;	b	field_16524
 METHOD	ab$b	(Lbod;)Lab$b;	a	method_15243
 METHOD	ab$b	(Lbod;Lbod;)Z	b	method_15078
-CLASS	aba	net/minecraft/class_3405
+CLASS	aba	net/minecraft/class_3406
 METHOD	aba	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15244
 METHOD	aba	(Lcom/mojang/datafixers/Dynamic;Ljava/lang/String;)Lcom/mojang/datafixers/Dynamic;	a	method_15245
 METHOD	aba	(Ljava/util/stream/Stream;)Ljava/util/stream/Stream;	a	method_15246
@@ -335,9 +335,9 @@ METHOD	aba	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	c	me
 METHOD	aba	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	d	method_15249
 METHOD	aba	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	e	method_15250
 METHOD	aba	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	abb	net/minecraft/class_3406
+CLASS	abb	net/minecraft/class_3407
 METHOD	abb	(Ljava/lang/String;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/util/Pair;	a	method_15251
-CLASS	abc	net/minecraft/class_3407
+CLASS	abc	net/minecraft/class_3408
 FIELD	abc	Ljava/lang/String;	a	field_16607
 METHOD	abc	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15252
 METHOD	abc	(Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15253
@@ -346,7 +346,7 @@ METHOD	abc	(Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType
 METHOD	abc	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15256
 METHOD	abc	(Ljava/lang/String;)Ljava/lang/String;	a	method_15257
 METHOD	abc	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	abd	net/minecraft/class_3408
+CLASS	abd	net/minecraft/class_3409
 FIELD	abd	Ljava/util/Set;	a	field_16608
 FIELD	abd	Ljava/util/Map;	b	field_16609
 FIELD	abd	Ljava/util/Map;	c	field_16610
@@ -358,20 +358,20 @@ METHOD	abd	(Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/Typed;)Lcom
 METHOD	abd	(Ljava/lang/String;)Ljava/lang/String;	a	method_15261
 METHOD	abd	(Ljava/lang/String;)Ljava/lang/String;	b	method_15262
 METHOD	abd	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	abe	net/minecraft/class_3409
+CLASS	abe	net/minecraft/class_3410
 METHOD	abe	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15263
 METHOD	abe	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15264
 METHOD	abe	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15265
 METHOD	abe	(Ljava/lang/String;)Ljava/lang/String;	a	method_15266
 METHOD	abe	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	abf	net/minecraft/class_3410
+CLASS	abf	net/minecraft/class_3411
 METHOD	abf	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15267
 METHOD	abf	(Lcom/mojang/datafixers/Dynamic;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_15268
 METHOD	abf	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_15269
 METHOD	abf	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15270
 METHOD	abf	(Ljava/lang/String;)Ljava/lang/String;	a	method_15271
 METHOD	abf	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	abg	net/minecraft/class_3411
+CLASS	abg	net/minecraft/class_3412
 FIELD	abg	Lorg/apache/logging/log4j/Logger;	a	field_16613
 METHOD	abg	(IILit/unimi/dsi/fastutil/ints/IntSet;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15272
 METHOD	abg	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15273
@@ -380,10 +380,10 @@ METHOD	abg	(Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType
 METHOD	abg	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15276
 METHOD	abg	(Ljava/lang/String;)Ljava/lang/String;	a	method_15277
 METHOD	abg	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	abg$a	net/minecraft/class_3411$class_3412
+CLASS	abg$a	net/minecraft/class_3412$class_3413
 FIELD	abg$a	Lit/unimi/dsi/fastutil/ints/IntSet;	f	field_16614
 METHOD	abg$a	(I)Z	a	method_15278
-CLASS	abh	net/minecraft/class_3413
+CLASS	abh	net/minecraft/class_3414
 METHOD	abh	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Ljava/util/function/Function;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15279
 METHOD	abh	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Ljava/util/function/Function;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15280
 METHOD	abh	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_15281
@@ -391,14 +391,14 @@ METHOD	abh	(Lcom/mojang/datafixers/OpticFinder;Ljava/util/function/Function;Lcom
 METHOD	abh	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_15283
 METHOD	abh	(Ljava/lang/String;)Ljava/lang/String;	a	method_15284
 METHOD	abh	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	b	method_15285
-CLASS	abi	net/minecraft/class_3414
+CLASS	abi	net/minecraft/class_3415
 FIELD	abi	Ljava/lang/String;	a	field_16615
 FIELD	abi	Lcom/mojang/datafixers/DSL$TypeReference;	b	field_16616
 METHOD	abi	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	abl	net/minecraft/class_3415
+CLASS	abl	net/minecraft/class_3416
 METHOD	abl	(Ljava/lang/String;)Ljava/lang/String;	a	method_15286
 METHOD	abl	(Lcom/mojang/datafixers/DSL$TypeReference;Ljava/lang/String;)Lcom/mojang/datafixers/types/Type;	getChoiceType	getChoiceType
-CLASS	abm	net/minecraft/class_3416
+CLASS	abm	net/minecraft/class_3417
 METHOD	abm	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15287
 METHOD	abm	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15288
 METHOD	abm	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V	a	method_15289
@@ -408,41 +408,41 @@ METHOD	abm	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/
 METHOD	abm	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	c	method_15293
 METHOD	abm	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
 METHOD	abm	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abn	net/minecraft/class_3417
+CLASS	abn	net/minecraft/class_3418
 METHOD	abn	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15294
 METHOD	abn	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abo	net/minecraft/class_3418
+CLASS	abo	net/minecraft/class_3419
 METHOD	abo	()Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15295
 METHOD	abo	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15296
 METHOD	abo	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	b	method_15297
 METHOD	abo	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abp	net/minecraft/class_3419
+CLASS	abp	net/minecraft/class_3420
 METHOD	abp	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15298
 METHOD	abp	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abq	net/minecraft/class_3420
+CLASS	abq	net/minecraft/class_3421
 METHOD	abq	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	abr	net/minecraft/class_3421
+CLASS	abr	net/minecraft/class_3422
 METHOD	abr	()Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15299
 METHOD	abr	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15300
 METHOD	abr	()Lcom/mojang/datafixers/types/templates/TypeTemplate;	b	method_15301
 METHOD	abr	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
 METHOD	abr	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abs	net/minecraft/class_3422
+CLASS	abs	net/minecraft/class_3423
 METHOD	abs	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15302
 METHOD	abs	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	b	method_15303
 METHOD	abs	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abt	net/minecraft/class_3423
+CLASS	abt	net/minecraft/class_3424
 METHOD	abt	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	abu	net/minecraft/class_3424
+CLASS	abu	net/minecraft/class_3425
 METHOD	abu	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15304
 METHOD	abu	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
-CLASS	abv	net/minecraft/class_3425
+CLASS	abv	net/minecraft/class_3426
 METHOD	abv	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15305
 METHOD	abv	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abw	net/minecraft/class_3426
+CLASS	abw	net/minecraft/class_3427
 METHOD	abw	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15306
 METHOD	abw	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
-CLASS	abx	net/minecraft/class_3427
+CLASS	abx	net/minecraft/class_3428
 METHOD	abx	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15307
 METHOD	abx	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15308
 METHOD	abx	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	b	method_15309
@@ -456,36 +456,36 @@ METHOD	abx	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/
 METHOD	abx	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	j	method_15317
 METHOD	abx	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	k	method_15318
 METHOD	abx	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	aby	net/minecraft/class_3428
+CLASS	aby	net/minecraft/class_3429
 METHOD	aby	()Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15319
 METHOD	aby	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	abz	net/minecraft/class_3429
+CLASS	abz	net/minecraft/class_3430
 METHOD	abz	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
-CLASS	ac	net/minecraft/class_3430
+CLASS	ac	net/minecraft/class_3431
 FIELD	ac	Lpc;	a	field_16617
 FIELD	ac	Ljava/util/Map;	b	field_16618
 METHOD	ac	(Ltf;Ljava/util/Collection;)V	a	method_15320
 METHOD	ac	()Lpc;	b	method_15321
 METHOD	ac	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lac$b;	b	method_15322
-CLASS	ac$a	net/minecraft/class_3430$class_3431
+CLASS	ac$a	net/minecraft/class_3431$class_3432
 FIELD	ac$a	Lpm;	a	field_16619
 FIELD	ac$a	Ljava/util/Set;	b	field_16620
 METHOD	ac$a	()Z	a	method_15323
 METHOD	ac$a	(Ls$a;)V	a	method_15324
 METHOD	ac$a	(Ltf;Ljava/util/Collection;)V	a	method_15325
 METHOD	ac$a	(Ls$a;)V	b	method_15326
-CLASS	ac$b	net/minecraft/class_3430$class_3432
+CLASS	ac$b	net/minecraft/class_3431$class_3433
 FIELD	ac$b	[Lao;	a	field_16621
 METHOD	ac$b	(Ltf;Ljava/util/Collection;)Z	a	method_15327
 METHOD	ac$b	([Lao;)Lac$b;	a	method_15328
-CLASS	aca	net/minecraft/class_3433
+CLASS	aca	net/minecraft/class_3434
 METHOD	aca	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15329
 METHOD	aca	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/function/Supplier;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15330
 METHOD	aca	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	acb	net/minecraft/class_3434
+CLASS	acb	net/minecraft/class_3435
 METHOD	acb	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15331
 METHOD	acb	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	acc	net/minecraft/class_3435
+CLASS	acc	net/minecraft/class_3436
 METHOD	acc	()Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15332
 METHOD	acc	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15333
 METHOD	acc	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15334
@@ -537,48 +537,48 @@ METHOD	acc	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang
 METHOD	acc	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	w	method_15377
 METHOD	acc	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	x	method_15378
 METHOD	acc	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	y	method_15379
-CLASS	acd	net/minecraft/class_3436
+CLASS	acd	net/minecraft/class_3437
 METHOD	acd	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15380
 METHOD	acd	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	b	method_15381
 METHOD	acd	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
 METHOD	acd	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	ace	net/minecraft/class_3437
+CLASS	ace	net/minecraft/class_3438
 METHOD	ace	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15382
 METHOD	ace	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15383
 METHOD	ace	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V	a	method_15384
 METHOD	ace	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	acf	net/minecraft/class_3438
+CLASS	acf	net/minecraft/class_3439
 METHOD	acf	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
-CLASS	acg	net/minecraft/class_3439
+CLASS	acg	net/minecraft/class_3440
 METHOD	acg	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	ach	net/minecraft/class_3440
+CLASS	ach	net/minecraft/class_3441
 METHOD	ach	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	aci	net/minecraft/class_3441
+CLASS	aci	net/minecraft/class_3442
 METHOD	aci	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	acj	net/minecraft/class_3442
+CLASS	acj	net/minecraft/class_3443
 METHOD	acj	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15385
 METHOD	acj	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V	a	method_15386
 METHOD	acj	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	ack	net/minecraft/class_3443
+CLASS	ack	net/minecraft/class_3444
 METHOD	ack	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15387
 METHOD	ack	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V	a	method_15388
 METHOD	ack	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	acl	net/minecraft/class_3444
+CLASS	acl	net/minecraft/class_3445
 METHOD	acl	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15389
 METHOD	acl	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V	a	method_15390
 METHOD	acl	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	acm	net/minecraft/class_3445
+CLASS	acm	net/minecraft/class_3446
 METHOD	acm	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15391
 METHOD	acm	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V	a	method_15392
 METHOD	acm	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	acn	net/minecraft/class_3446
+CLASS	acn	net/minecraft/class_3447
 METHOD	acn	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15393
 METHOD	acn	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	b	method_15394
 METHOD	acn	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	c	method_15395
 METHOD	acn	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	d	method_15396
 METHOD	acn	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	e	method_15397
 METHOD	acn	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
-CLASS	aco	net/minecraft/class_3447
+CLASS	aco	net/minecraft/class_3448
 FIELD	aco	Ljava/util/Map;	a	field_16622
 FIELD	aco	Lcom/mojang/datafixers/types/templates/Hook$HookFunction;	b	field_16623
 METHOD	aco	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15398
@@ -592,9 +592,9 @@ METHOD	aco	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang
 METHOD	aco	(Lcom/mojang/datafixers/DSL$TypeReference;Ljava/lang/String;)Lcom/mojang/datafixers/types/Type;	getChoiceType	getChoiceType
 METHOD	aco	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
 METHOD	aco	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	aco$1	net/minecraft/class_3447$1
+CLASS	aco$1	net/minecraft/class_3448$1
 METHOD	aco$1	(Lcom/mojang/datafixers/types/DynamicOps;Ljava/lang/Object;)Ljava/lang/Object;	apply	apply
-CLASS	acp	net/minecraft/class_3448
+CLASS	acp	net/minecraft/class_3449
 FIELD	acp	Lcom/mojang/datafixers/types/templates/Hook$HookFunction;	a	field_16624
 METHOD	acp	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15406
 METHOD	acp	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15407
@@ -626,13 +626,13 @@ METHOD	acp	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang
 METHOD	acp	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	t	method_15431
 METHOD	acp	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	u	method_15432
 METHOD	acp	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	v	method_15433
-CLASS	acp$1	net/minecraft/class_3448$1
+CLASS	acp$1	net/minecraft/class_3449$1
 METHOD	acp$1	(Lcom/mojang/datafixers/types/DynamicOps;Ljava/lang/Object;)Ljava/lang/Object;	apply	apply
-CLASS	acq	net/minecraft/class_3449
+CLASS	acq	net/minecraft/class_3450
 METHOD	acq	(Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;	a	method_15434
 METHOD	acq	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V	a	method_15435
 METHOD	acq	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
-CLASS	acr	net/minecraft/class_3450
+CLASS	acr	net/minecraft/class_3451
 FIELD	acr	Lcom/mojang/datafixers/types/templates/Hook$HookFunction;	a	field_16625
 FIELD	acr	Lorg/apache/logging/log4j/Logger;	b	field_16626
 FIELD	acr	Ljava/util/Map;	c	field_16627
@@ -682,16 +682,16 @@ METHOD	acr	(Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)Lcom/mojang
 METHOD	acr	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerBlockEntities	registerBlockEntities
 METHOD	acr	(Lcom/mojang/datafixers/schemas/Schema;)Ljava/util/Map;	registerEntities	registerEntities
 METHOD	acr	(Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/util/Map;)V	registerTypes	registerTypes
-CLASS	acr$1	net/minecraft/class_3450$1
+CLASS	acr$1	net/minecraft/class_3451$1
 METHOD	acr$1	(Lcom/mojang/datafixers/types/DynamicOps;Ljava/lang/Object;)Ljava/lang/Object;	apply	apply
-CLASS	act	net/minecraft/class_3451
+CLASS	act	net/minecraft/class_3452
 FIELD	act	Lorg/apache/logging/log4j/Logger;	a	field_16628
 FIELD	act	Ljava/lang/ThreadGroup;	b	field_16629
 FIELD	act	Ljava/util/concurrent/atomic/AtomicInteger;	c	field_16630
 FIELD	act	Ljava/lang/String;	d	field_16631
 METHOD	act	(Ljava/lang/Runnable;Ljava/lang/Thread;Ljava/lang/Throwable;)V	a	method_15479
 METHOD	act	(Ljava/lang/Runnable;)Ljava/lang/Thread;	newThread	newThread
-CLASS	acu	net/minecraft/class_3452
+CLASS	acu	net/minecraft/class_3453
 FIELD	acu	Ljava/util/concurrent/ExecutorService;	a	field_16632
 FIELD	acu	Lorg/apache/logging/log4j/Logger;	b	field_16633
 FIELD	acu	Ljava/util/concurrent/ExecutorService;	c	field_16634
@@ -721,10 +721,10 @@ METHOD	acu	(Ljava/lang/Object;Z)Ljava/lang/Object;	b	method_15495
 METHOD	acu	()Ljava/util/concurrent/CompletableFuture;	c	method_15496
 METHOD	acu	(Lacu;)Ljava/util/concurrent/atomic/AtomicInteger;	c	method_15497
 METHOD	acu	(Ljava/lang/Object;)Ljava/lang/Object;	d	method_15498
-CLASS	acu$1	net/minecraft/class_3452$1
+CLASS	acu$1	net/minecraft/class_3453$1
 FIELD	acu$1	Ljava/lang/String;	a	field_16642
 FIELD	acu$1	Lacu;	b	field_16643
-CLASS	acu$a	net/minecraft/class_3452$class_3453
+CLASS	acu$a	net/minecraft/class_3453$class_3454
 FIELD	acu$a	Lacu;	a	field_16644
 FIELD	acu$a	Ljava/util/Map;	b	field_16645
 FIELD	acu$a	Ljava/lang/Object;	c	field_16646
@@ -741,7 +741,7 @@ METHOD	acu$a	(Ljava/util/concurrent/CompletableFuture;Lacx;)Ljava/util/concurren
 CLASS	acv	net/minecraft/class_2605
 METHOD	acv	(Ljava/lang/Runnable;)Lcom/google/common/util/concurrent/ListenableFuture;	a	method_6635
 METHOD	acv	()Z	av	method_6640
-CLASS	acw	net/minecraft/class_3454
+CLASS	acw	net/minecraft/class_3455
 FIELD	acw	Lorg/apache/logging/log4j/Logger;	a	field_16648
 FIELD	acw	Lacu;	b	field_16649
 FIELD	acw	Z	c	field_16650
@@ -750,10 +750,10 @@ METHOD	acw	()V	a	method_15508
 METHOD	acw	(Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;	a	method_15509
 METHOD	acw	()V	b	method_15510
 METHOD	acw	()Ljava/util/concurrent/CompletableFuture;	c	method_15511
-CLASS	acx	net/minecraft/class_3455
+CLASS	acx	net/minecraft/class_3456
 METHOD	acx	()Lacx;	a	method_15512
 METHOD	acx	(Ljava/lang/Object;Ljava/util/function/BiConsumer;)V	a	method_15513
-CLASS	acz	net/minecraft/class_3456
+CLASS	acz	net/minecraft/class_3457
 FIELD	acz	Ljava/util/regex/Pattern;	a	field_16652
 FIELD	acz	Ljava/io/File;	b	field_16653
 FIELD	acz	Ljava/util/Map;	c	field_16654
@@ -762,24 +762,24 @@ METHOD	acz	(Ljava/io/File;)Ljava/util/List;	a	method_15515
 METHOD	acz	(Ljava/io/File;Ljava/lang/String;)Z	a	method_15516
 METHOD	acz	(Lbod;)Ljava/util/List;	b	method_15517
 METHOD	acz	(Ljava/io/File;)Ljava/util/List;	b	method_15518
-CLASS	ad	net/minecraft/class_3376
+CLASS	ad	net/minecraft/class_3377
 FIELD	ad	Lpc;	a	field_16539
 FIELD	ad	Ljava/util/Map;	b	field_16540
 METHOD	ad	(Ltf;Lbjg;)V	a	method_15081
 METHOD	ad	()Lpc;	b	method_15082
 METHOD	ad	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lad$b;	b	method_15083
-CLASS	ad$a	net/minecraft/class_3376$class_3377
+CLASS	ad$a	net/minecraft/class_3377$class_3378
 FIELD	ad$a	Lpm;	a	field_16541
 FIELD	ad$a	Ljava/util/Set;	b	field_16542
 METHOD	ad$a	()Z	a	method_15084
 METHOD	ad$a	(Lbjg;)V	a	method_15085
 METHOD	ad$a	(Ls$a;)V	a	method_15086
 METHOD	ad$a	(Ls$a;)V	b	method_15087
-CLASS	ad$b	net/minecraft/class_3376$class_3378
+CLASS	ad$b	net/minecraft/class_3377$class_3379
 FIELD	ad$b	Lba$d;	a	field_16543
 METHOD	ad$b	(Lba$d;)Lad$b;	a	method_15519
 METHOD	ad$b	(Lbjg;)Z	a	method_15088
-CLASS	ada	net/minecraft/class_3457
+CLASS	ada	net/minecraft/class_3458
 FIELD	ada	Lorg/apache/logging/log4j/Logger;	a	field_16655
 FIELD	ada	Ljava/util/concurrent/ThreadFactory;	b	field_16656
 FIELD	ada	Ljava/lang/String;	c	field_16657
@@ -1029,20 +1029,20 @@ METHOD	adz	()V	g	method_5369
 METHOD	adz	()Lafa;	h	method_10917
 METHOD	adz	()Ladx;	j	method_5367
 METHOD	adz	()V	k	method_5368
-CLASS	ae	net/minecraft/class_3380
+CLASS	ae	net/minecraft/class_3381
 FIELD	ae	Lpc;	a	field_16545
 FIELD	ae	Ljava/util/Map;	b	field_16546
 METHOD	ae	(Ltf;Late;)V	a	method_15090
 METHOD	ae	()Lpc;	b	method_15091
 METHOD	ae	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lae$b;	b	method_15092
-CLASS	ae$a	net/minecraft/class_3380$class_3381
+CLASS	ae$a	net/minecraft/class_3381$class_3382
 FIELD	ae$a	Lpm;	a	field_16547
 FIELD	ae$a	Ljava/util/Set;	b	field_16548
 METHOD	ae$a	()Z	a	method_15093
 METHOD	ae$a	(Late;)V	a	method_15094
 METHOD	ae$a	(Ls$a;)V	a	method_15095
 METHOD	ae$a	(Ls$a;)V	b	method_15096
-CLASS	ae$b	net/minecraft/class_3380$class_3382
+CLASS	ae$b	net/minecraft/class_3381$class_3383
 FIELD	ae$b	Lav;	a	field_16549
 METHOD	ae$b	(Late;)Z	a	method_15097
 METHOD	ae$b	(Laxx;)Lae$b;	a	method_15543
@@ -1121,7 +1121,7 @@ METHOD	aeb	()Laeb;	x	method_10919
 METHOD	aeb	()Z	y	method_10920
 CLASS	aec	net/minecraft/class_858
 FIELD	aec	Laer;	x	field_3149
-CLASS	aed	net/minecraft/class_3458
+CLASS	aed	net/minecraft/class_3459
 METHOD	aed	(Lip;)V	a	method_15547
 CLASS	aef	net/minecraft/class_1695
 CLASS	aeg	net/minecraft/class_1696
@@ -1190,7 +1190,7 @@ METHOD	aek	()Z	h	method_5376
 METHOD	aek	()I	hashCode	hashCode
 METHOD	aek	()I	i	method_2457
 METHOD	aek	()Ljava/lang/String;	toString	toString
-CLASS	ael	net/minecraft/class_3459
+CLASS	ael	net/minecraft/class_3460
 METHOD	ael	(Laek;F)Ljava/lang/String;	a	method_15553
 METHOD	ael	(Lafa;)Z	a	method_15554
 METHOD	ael	(Lafa;)I	b	method_15555
@@ -1654,7 +1654,7 @@ CLASS	aeu$a	net/minecraft/class_1394$class_1565
 FIELD	aeu$a	Late;	a	field_6121
 METHOD	aeu$a	(Laer;)Z	a	method_10976
 METHOD	aeu$a	(Ljava/lang/Object;)Z	test	test
-CLASS	aev	net/minecraft/class_3460
+CLASS	aev	net/minecraft/class_3461
 FIELD	aev	Laev;	A	field_16706
 FIELD	aev	Laev;	B	field_16707
 FIELD	aev	Laev;	C	field_16708
@@ -1777,7 +1777,7 @@ METHOD	aev	()Ljava/lang/Class;	c	method_15628
 METHOD	aev	()Ljava/lang/String;	d	method_15629
 METHOD	aev	()Lij;	e	method_15630
 METHOD	aev	()Lorg/apache/logging/log4j/Logger;	f	method_15631
-CLASS	aev$a	net/minecraft/class_3460$class_3461
+CLASS	aev$a	net/minecraft/class_3461$class_3462
 FIELD	aev$a	Ljava/lang/Class;	a	field_16809
 FIELD	aev$a	Ljava/util/function/Function;	b	field_16810
 FIELD	aev$a	Z	c	field_16811
@@ -2182,7 +2182,7 @@ METHOD	afc	()Z	c	method_2678
 METHOD	afc	()Z	d	method_4487
 METHOD	afc	(Ljava/lang/String;)Lafc;	valueOf	valueOf
 METHOD	afc	()[Lafc;	values	values
-CLASS	afd	net/minecraft/class_3462
+CLASS	afd	net/minecraft/class_3463
 FIELD	afd	Lafd;	a	field_16818
 FIELD	afd	Lafd;	b	field_16819
 FIELD	afd	Lafd;	c	field_16820
@@ -2228,14 +2228,14 @@ METHOD	afk	(Laev;Lafk$b;Lbor$a;)V	a	method_15659
 METHOD	afk	(Laev;Lafk$b;Lbor$a;Lwz;)V	a	method_15660
 METHOD	afk	(Laev;Lblc;)Z	a	method_15661
 METHOD	afk	(Laev;)Lbor$a;	b	method_15662
-CLASS	afk$a	net/minecraft/class_2613$class_3463
+CLASS	afk$a	net/minecraft/class_2613$class_3464
 FIELD	afk$a	Lbor$a;	a	field_16824
 FIELD	afk$a	Lafk$b;	b	field_16825
 FIELD	afk$a	Lwz;	c	field_16826
 METHOD	afk$a	(Lafk$a;)Lafk$b;	a	method_15663
 METHOD	afk$a	(Lafk$a;)Lbor$a;	b	method_15664
 METHOD	afk$a	(Lafk$a;)Lwz;	c	method_15665
-CLASS	afk$b	net/minecraft/class_2613$class_3464
+CLASS	afk$b	net/minecraft/class_2613$class_3465
 FIELD	afk$b	Lafk$b;	a	field_16827
 FIELD	afk$b	Lafk$b;	b	field_16828
 FIELD	afk$b	[Lafk$b;	c	field_16829
@@ -2344,9 +2344,9 @@ FIELD	afv	I	b	field_3429
 FIELD	afv	F	c	field_3430
 METHOD	afv	()V	a	method_2722
 METHOD	afv	(FFF)F	a	method_2723
-CLASS	afx	net/minecraft/class_3465
+CLASS	afx	net/minecraft/class_3466
 FIELD	afx	I	h	field_16831
-CLASS	afy	net/minecraft/class_3369
+CLASS	afy	net/minecraft/class_3370
 CLASS	afz	net/minecraft/class_882
 FIELD	afz	Z	a	field_3432
 FIELD	afz	Lafb;	b	field_3431
@@ -2362,7 +2362,7 @@ FIELD	ag	Lah;	f	field_15575
 METHOD	ag	()Lcom/google/gson/JsonElement;	a	method_15668
 METHOD	ag	(Lcom/google/gson/JsonElement;)Lag;	a	method_14116
 METHOD	ag	(Ltf;Laea;FFZ)Z	a	method_14117
-CLASS	ag$a	net/minecraft/class_3160$class_3466
+CLASS	ag$a	net/minecraft/class_3160$class_3467
 FIELD	ag$a	Lba$c;	a	field_16833
 FIELD	ag$a	Lba$c;	b	field_16834
 FIELD	ag$a	Lao;	c	field_16835
@@ -2441,7 +2441,7 @@ FIELD	age	Layc;	c	field_16841
 FIELD	age	F	d	field_3465
 FIELD	age	I	e	field_3466
 METHOD	age	(Laog;)Z	a	method_2736
-CLASS	agf	net/minecraft/class_3467
+CLASS	agf	net/minecraft/class_3468
 FIELD	agf	Lagf;	a	field_16842
 FIELD	agf	Lagf;	b	field_16843
 FIELD	agf	[Lagf;	c	field_16844
@@ -2450,7 +2450,7 @@ METHOD	agf	()[Lagf;	values	values
 CLASS	agg	net/minecraft/class_888
 FIELD	agg	I	d	field_3467
 FIELD	agg	I	e	field_3468
-CLASS	agh	net/minecraft/class_3468
+CLASS	agh	net/minecraft/class_3469
 FIELD	agh	Lafg;	a	field_16845
 METHOD	agh	(Layc;Lel;)Z	a	method_15676
 METHOD	agh	()V	g	method_15677
@@ -2489,19 +2489,19 @@ FIELD	agl	Laxy;	f	field_3490
 METHOD	agl	()Lcee;	g	method_2741
 CLASS	agm	net/minecraft/class_893
 FIELD	agm	Lafb;	a	field_3491
-CLASS	agn	net/minecraft/class_3469
+CLASS	agn	net/minecraft/class_3470
 FIELD	agn	I	a	field_16848
 FIELD	agn	Lafg;	b	field_16849
 FIELD	agn	Lafa;	c	field_16850
 FIELD	agn	Lagf;	d	field_16851
-CLASS	ago	net/minecraft/class_3470
+CLASS	ago	net/minecraft/class_3471
 FIELD	ago	Lajp;	a	field_16852
 FIELD	ago	I	b	field_16853
 FIELD	ago	I	c	field_16854
 METHOD	ago	(Lajp;)I	a	method_15681
 METHOD	ago	(Lajp;)Z	b	method_15682
 METHOD	ago	(Lajp;)Z	c	method_15683
-CLASS	agp	net/minecraft/class_3373
+CLASS	agp	net/minecraft/class_3374
 FIELD	agp	Lafb;	a	field_16525
 FIELD	agp	Ljava/util/function/Predicate;	b	field_16855
 FIELD	agp	Lafb;	c	field_16527
@@ -2512,7 +2512,7 @@ FIELD	agp	F	g	field_16531
 FIELD	agp	F	h	field_16532
 FIELD	agp	F	i	field_16533
 METHOD	agp	(Lafb;Lafb;)Z	a	method_15684
-CLASS	agq	net/minecraft/class_3374
+CLASS	agq	net/minecraft/class_3375
 CLASS	agr	net/minecraft/class_894
 FIELD	agr	Layc;	a	field_16856
 FIELD	agr	Lafl;	b	field_3495
@@ -2570,7 +2570,7 @@ FIELD	agv	Z	g	field_11934
 FIELD	agv	Z	h	field_11935
 FIELD	agv	I	i	field_11936
 CLASS	agw	net/minecraft/class_899
-CLASS	agx	net/minecraft/class_3471
+CLASS	agx	net/minecraft/class_3472
 FIELD	agx	[I	a	field_16857
 FIELD	agx	Laju;	b	field_16858
 FIELD	agx	I	c	field_16859
@@ -2578,7 +2578,7 @@ FIELD	agx	Z	d	field_16860
 METHOD	agx	(FFF)F	a	method_15685
 METHOD	agx	(Lel;III)Z	a	method_15686
 METHOD	agx	(Lel;III)Z	b	method_15687
-CLASS	agy	net/minecraft/class_3375
+CLASS	agy	net/minecraft/class_3376
 FIELD	agy	Lakg;	a	field_16536
 FIELD	agy	Laog;	b	field_16537
 FIELD	agy	Z	c	field_16538
@@ -2602,7 +2602,7 @@ METHOD	ah	(Lcom/google/gson/JsonElement;)Lah;	a	method_14118
 METHOD	ah	(Lcom/google/gson/JsonObject;Ljava/lang/String;)Ljava/lang/Boolean;	a	method_14119
 METHOD	ah	(Lcom/google/gson/JsonObject;Ljava/lang/String;Ljava/lang/Boolean;)V	a	method_15689
 METHOD	ah	(Ltf;Laea;)Z	a	method_14120
-CLASS	ah$a	net/minecraft/class_3161$class_3472
+CLASS	ah$a	net/minecraft/class_3161$class_3473
 FIELD	ah$a	Ljava/lang/Boolean;	a	field_16871
 FIELD	ah$a	Ljava/lang/Boolean;	b	field_16872
 FIELD	ah$a	Ljava/lang/Boolean;	c	field_16873
@@ -2741,7 +2741,7 @@ FIELD	ahr	Z	g	field_11946
 METHOD	ahr	(I)V	b	method_11015
 METHOD	ahr	()Lcee;	g	method_13954
 METHOD	ahr	()V	i	method_11016
-CLASS	ahs	net/minecraft/class_3473
+CLASS	ahs	net/minecraft/class_3474
 CLASS	aht	net/minecraft/class_885
 FIELD	aht	Lafb;	a	field_3447
 FIELD	aht	Lanj;	b	field_5357
@@ -2765,7 +2765,7 @@ FIELD	ahu	Z	h	field_14591
 FIELD	ahu	I	i	field_14592
 METHOD	ahu	(I)V	b	method_13101
 METHOD	ahu	()Z	g	method_13102
-CLASS	ahv	net/minecraft/class_3474
+CLASS	ahv	net/minecraft/class_3475
 FIELD	ahv	Lbcs;	f	field_16883
 FIELD	ahv	Lafb;	g	field_16884
 FIELD	ahv	I	h	field_16885
@@ -2824,12 +2824,12 @@ METHOD	aic	(Late;)Z	a	method_13103
 METHOD	aic	()Z	g	method_2766
 CLASS	aid	net/minecraft/class_924
 FIELD	aid	Laob;	a	field_3621
-CLASS	aie	net/minecraft/class_3475
+CLASS	aie	net/minecraft/class_3476
 FIELD	aie	Lafg;	a	field_16887
 CLASS	aif	net/minecraft/class_2617
 FIELD	aif	I	e	field_11947
 FIELD	aif	Laob;	f	field_11948
-CLASS	aig	net/minecraft/class_3379
+CLASS	aig	net/minecraft/class_3380
 METHOD	aig	()Lcee;	j	method_15089
 CLASS	aih	net/minecraft/class_3133
 FIELD	aih	F	h	field_15483
@@ -2902,7 +2902,7 @@ METHOD	ais	(Lafa;Z)Z	a	method_6221
 METHOD	ais	(Lafb;Lafa;ZZ)Z	a	method_11025
 METHOD	ais	(I)Lais;	b	method_13955
 METHOD	ais	()D	i	method_6222
-CLASS	aiu	net/minecraft/class_3383
+CLASS	aiu	net/minecraft/class_3384
 METHOD	aiu	(Z)V	a	method_15098
 METHOD	aiu	(Z)V	b	method_15099
 CLASS	aiv	net/minecraft/class_2620
@@ -2981,7 +2981,7 @@ METHOD	aj$a	()Z	a	method_14143
 METHOD	aj$a	(Ls$a;)V	a	method_14145
 METHOD	aj$a	(Ltf;)V	a	method_14144
 METHOD	aj$a	(Ls$a;)V	b	method_14146
-CLASS	aj$b	net/minecraft/class_3171$class_3476
+CLASS	aj$b	net/minecraft/class_3171$class_3477
 FIELD	aj$b	Lbb;	a	field_16892
 METHOD	aj$b	(Lbb;)Laj$b;	a	method_15713
 METHOD	aj$b	(Ltf;)Z	a	method_15714
@@ -3117,7 +3117,7 @@ FIELD	ajl	Lel;	b	field_5365
 METHOD	ajl	(Z)V	a	method_4514
 METHOD	ajl	()Z	dr	method_15720
 METHOD	ajl	()Z	l	method_4515
-CLASS	ajn	net/minecraft/class_3477
+CLASS	ajn	net/minecraft/class_3478
 FIELD	ajn	Lor;	a	field_16893
 METHOD	ajn	(Z)V	a	method_15721
 METHOD	ajn	()Z	dA	method_15722
@@ -3125,12 +3125,12 @@ METHOD	ajn	()Z	dy	method_15723
 METHOD	ajn	()Lwi;	dz	method_15724
 METHOD	ajn	(Late;)V	f	method_15725
 METHOD	ajn	()Late;	l	method_15726
-CLASS	ajn$a	net/minecraft/class_3477$class_3478
+CLASS	ajn$a	net/minecraft/class_3478$class_3479
 FIELD	ajn$a	Lajn;	i	field_16894
-CLASS	ajn$b	net/minecraft/class_3477$class_3008
+CLASS	ajn$b	net/minecraft/class_3478$class_3008
 FIELD	ajn$b	Lajn;	h	field_16895
 CLASS	ajo	net/minecraft/class_945
-CLASS	ajp	net/minecraft/class_3479
+CLASS	ajp	net/minecraft/class_3480
 FIELD	ajp	Lajp;	a	field_16896
 FIELD	ajp	I	b	field_16897
 METHOD	ajp	(Lajp;)Lajp;	a	method_15727
@@ -3146,7 +3146,7 @@ METHOD	ajp	()Z	dF	method_15736
 METHOD	ajp	()V	dG	method_15737
 METHOD	ajp	()V	dH	method_15738
 METHOD	ajp	()V	dI	method_15739
-CLASS	ajp$a	net/minecraft/class_3479$class_3480
+CLASS	ajp$a	net/minecraft/class_3480$class_3481
 FIELD	ajp$a	Lajp;	a	field_16898
 CLASS	ajq	net/minecraft/class_942
 FIELD	ajq	I	bC	field_3696
@@ -3173,10 +3173,10 @@ FIELD	ajr	Lavh;	bK	field_16899
 METHOD	ajr	(Laeo;)Lajr;	b	method_4516
 METHOD	ajr	()Z	dy	method_8387
 METHOD	ajr	(Z)V	s	method_8388
-CLASS	ajs	net/minecraft/class_3481
+CLASS	ajs	net/minecraft/class_3482
 CLASS	ajt	net/minecraft/class_944
 METHOD	ajt	(Laeo;)Lajt;	b	method_4517
-CLASS	aju	net/minecraft/class_3482
+CLASS	aju	net/minecraft/class_3483
 FIELD	aju	Ljava/util/function/Predicate;	a	field_16900
 FIELD	aju	Lor;	bC	field_16901
 FIELD	aju	Lor;	b	field_16902
@@ -3192,20 +3192,20 @@ METHOD	aju	()I	dz	method_15749
 METHOD	aju	(Late;)Lamm;	f	method_15750
 METHOD	aju	(Lel;)V	g	method_15751
 METHOD	aju	()Lel;	l	method_15752
-CLASS	aju$1	net/minecraft/class_3482$1
-CLASS	aju$a	net/minecraft/class_3482$class_3483
+CLASS	aju$1	net/minecraft/class_3483$1
+CLASS	aju$a	net/minecraft/class_3483$class_3484
 FIELD	aju$a	Laju;	i	field_16904
-CLASS	aju$b	net/minecraft/class_3482$class_3484
+CLASS	aju$b	net/minecraft/class_3483$class_3485
 FIELD	aju$b	Laju;	a	field_16905
 FIELD	aju$b	Z	b	field_16906
-CLASS	aju$c	net/minecraft/class_3482$class_3485
+CLASS	aju$c	net/minecraft/class_3483$class_3486
 FIELD	aju$c	Laju;	a	field_16907
 FIELD	aju$c	D	b	field_16908
 FIELD	aju$c	Laog;	c	field_16909
-CLASS	aju$d	net/minecraft/class_3482$class_3486
+CLASS	aju$d	net/minecraft/class_3483$class_3487
 FIELD	aju$d	Laju;	a	field_16910
 FIELD	aju$d	I	b	field_16911
-CLASS	ajv	net/minecraft/class_3384
+CLASS	ajv	net/minecraft/class_3385
 CLASS	ajw	net/minecraft/class_952
 FIELD	ajw	Lor;	a	field_14623
 FIELD	ajw	I	bC	field_3725
@@ -3271,7 +3271,7 @@ METHOD	ak$a	()Z	a	method_14198
 METHOD	ak$a	(Late;I)V	a	method_14199
 METHOD	ak$a	(Ls$a;)V	a	method_14200
 METHOD	ak$a	(Ls$a;)V	b	method_14201
-CLASS	ak$b	net/minecraft/class_3177$class_3487
+CLASS	ak$b	net/minecraft/class_3177$class_3488
 FIELD	ak$b	Lav;	a	field_16916
 FIELD	ak$b	Lba$d;	b	field_16917
 METHOD	ak$b	(Late;I)Z	a	method_15758
@@ -3307,7 +3307,7 @@ CLASS	akb$d	net/minecraft/class_3033$class_3037
 FIELD	akb$d	Lakb;	d	field_15038
 CLASS	akb$e	net/minecraft/class_3033$class_3038
 FIELD	akb$e	Lakb;	f	field_15039
-CLASS	akc	net/minecraft/class_3488
+CLASS	akc	net/minecraft/class_3489
 FIELD	akc	Lor;	a	field_16919
 FIELD	akc	Ljava/util/function/Predicate;	bC	field_16920
 FIELD	akc	F	bD	field_16921
@@ -3323,7 +3323,7 @@ METHOD	akc	(I)V	d	method_15765
 METHOD	akc	()I	dA	method_15766
 METHOD	akc	()Ljava/util/function/Predicate;	dB	method_15767
 METHOD	akc	(Lafa;)Z	f	method_15768
-CLASS	akc$a	net/minecraft/class_3488$class_3489
+CLASS	akc$a	net/minecraft/class_3489$class_3490
 FIELD	akc$a	Lakc;	a	field_16925
 CLASS	akd	net/minecraft/class_2623
 FIELD	akd	Lor;	bC	field_14618
@@ -3373,7 +3373,7 @@ CLASS	akd$g	net/minecraft/class_2623$class_2631
 FIELD	akd$g	Lakd;	f	field_12003
 FIELD	akd$g	Z	g	field_12004
 FIELD	akd$g	Z	h	field_12005
-CLASS	ake	net/minecraft/class_3490
+CLASS	ake	net/minecraft/class_3491
 CLASS	akf	net/minecraft/class_949
 FIELD	akf	Lor;	bC	field_14620
 FIELD	akf	Laqc;	bD	field_5369
@@ -3427,13 +3427,13 @@ METHOD	aki	(FFF)V	c	method_11105
 METHOD	aki	()V	dy	method_15773
 METHOD	aki	()Z	l	method_11106
 CLASS	aki$1	net/minecraft/class_951$1
-CLASS	aki$a	net/minecraft/class_951$class_3491
+CLASS	aki$a	net/minecraft/class_951$class_3492
 FIELD	aki$a	Laki;	a	field_16928
 FIELD	aki$a	I	b	field_16929
 CLASS	aki$b	net/minecraft/class_951$class_2632
 FIELD	aki$b	Laki;	a	field_16930
 FIELD	aki$b	Laki;	b	field_12007
-CLASS	akj	net/minecraft/class_3492
+CLASS	akj	net/minecraft/class_3493
 FIELD	akj	[I	a	field_16931
 FIELD	akj	[Lpc;	bC	field_16932
 FIELD	akj	[Lpc;	bD	field_16933
@@ -3456,8 +3456,8 @@ METHOD	akj	(I)I	s	method_15786
 METHOD	akj	(I)I	t	method_15787
 METHOD	akj	(I)I	u	method_15788
 METHOD	akj	(I)I	v	method_15789
-CLASS	akj$1	net/minecraft/class_3492$1
-CLASS	akj$a	net/minecraft/class_3492$class_3493
+CLASS	akj$1	net/minecraft/class_3493$1
+CLASS	akj$a	net/minecraft/class_3493$class_3494
 FIELD	akj$a	Lakj$a;	a	field_16937
 FIELD	akj$a	Lakj$a;	b	field_16938
 FIELD	akj$a	Lakj$a;	c	field_16939
@@ -3480,7 +3480,7 @@ METHOD	akj$a	()I	b	method_15792
 METHOD	akj$a	()Ljava/lang/String;	c	method_15793
 METHOD	akj$a	(Ljava/lang/String;)Lakj$a;	valueOf	valueOf
 METHOD	akj$a	()[Lakj$a;	values	values
-CLASS	akj$b	net/minecraft/class_3492$class_3494
+CLASS	akj$b	net/minecraft/class_3493$class_3495
 FIELD	akj$b	I	b	field_16953
 FIELD	akj$b	I	c	field_16954
 FIELD	akj$b	I	d	field_16955
@@ -3489,7 +3489,7 @@ METHOD	akj$b	(Lakj$b;)I	a	method_15794
 METHOD	akj$b	(Lakj$b;)I	b	method_15795
 METHOD	akj$b	(Lakj$b;)I	c	method_15796
 METHOD	akj$b	(Lakj$b;)I	d	method_15797
-CLASS	akk	net/minecraft/class_3495
+CLASS	akk	net/minecraft/class_3496
 FIELD	akk	Ljava/util/function/Predicate;	bC	field_16957
 FIELD	akk	Lor;	bD	field_16958
 FIELD	akk	Lor;	bE	field_16959
@@ -3524,33 +3524,33 @@ METHOD	akk	(Z)V	s	method_15820
 METHOD	akk	(Z)V	t	method_15821
 METHOD	akk	(Z)V	u	method_15822
 METHOD	akk	(Z)V	v	method_15823
-CLASS	akk$1	net/minecraft/class_3495$1
-CLASS	akk$a	net/minecraft/class_3495$class_3496
+CLASS	akk$1	net/minecraft/class_3496$1
+CLASS	akk$a	net/minecraft/class_3496$class_3497
 FIELD	akk$a	Lakk;	d	field_16965
-CLASS	akk$b	net/minecraft/class_3495$class_3497
+CLASS	akk$b	net/minecraft/class_3496$class_3498
 FIELD	akk$b	Lakk;	a	field_16966
 FIELD	akk$b	D	b	field_16967
 FIELD	akk$b	Z	c	field_16968
 FIELD	akk$b	I	d	field_16969
-CLASS	akk$c	net/minecraft/class_3495$class_3498
+CLASS	akk$c	net/minecraft/class_3496$class_3499
 FIELD	akk$c	Lakk;	f	field_16970
-CLASS	akk$d	net/minecraft/class_3495$class_3499
+CLASS	akk$d	net/minecraft/class_3496$class_3500
 FIELD	akk$d	Lakk;	f	field_16971
-CLASS	akk$e	net/minecraft/class_3495$class_3500
+CLASS	akk$e	net/minecraft/class_3496$class_3501
 FIELD	akk$e	Lakk;	i	field_16972
 METHOD	akk$e	()V	g	method_15824
-CLASS	akk$f	net/minecraft/class_3495$class_3501
-CLASS	akk$g	net/minecraft/class_3495$class_3502
-CLASS	akk$h	net/minecraft/class_3495$class_3503
+CLASS	akk$f	net/minecraft/class_3496$class_3502
+CLASS	akk$g	net/minecraft/class_3496$class_3503
+CLASS	akk$h	net/minecraft/class_3496$class_3504
 FIELD	akk$h	Lakk;	h	field_16973
-CLASS	akk$i	net/minecraft/class_3495$class_3504
+CLASS	akk$i	net/minecraft/class_3496$class_3505
 FIELD	akk$i	Lakk;	a	field_16974
 FIELD	akk$i	D	b	field_16975
 FIELD	akk$i	Laog;	c	field_16976
 FIELD	akk$i	I	d	field_16977
 FIELD	akk$i	Ljava/util/Set;	e	field_16978
 METHOD	akk$i	(Late;)Z	a	method_15825
-CLASS	akk$j	net/minecraft/class_3495$class_3505
+CLASS	akk$j	net/minecraft/class_3496$class_3506
 FIELD	akk$j	Lakk;	a	field_16979
 FIELD	akk$j	D	b	field_16980
 FIELD	akk$j	Z	c	field_16981
@@ -4021,7 +4021,7 @@ METHOD	am$a	()Z	a	method_14215
 METHOD	am$a	(Lblc;)V	a	method_14216
 METHOD	am$a	(Ls$a;)V	a	method_14217
 METHOD	am$a	(Ls$a;)V	b	method_14218
-CLASS	am$b	net/minecraft/class_3181$class_3506
+CLASS	am$b	net/minecraft/class_3181$class_3507
 FIELD	am$b	Lbcs;	a	field_16987
 FIELD	am$b	Ljava/util/Map;	b	field_16988
 METHOD	am$b	(Lbcs;)Lam$b;	a	method_15835
@@ -4062,7 +4062,7 @@ FIELD	amb$1	[I	a	field_16992
 CLASS	amc	net/minecraft/class_1698
 METHOD	amc	(Laxy;Lel;)Lamc;	a	method_11153
 METHOD	amc	(Laxy;Lel;)Lamc;	b	method_11154
-CLASS	amd	net/minecraft/class_3507
+CLASS	amd	net/minecraft/class_3508
 FIELD	amd	I	A	field_16993
 FIELD	amd	I	B	field_16994
 FIELD	amd	I	C	field_16995
@@ -4248,7 +4248,7 @@ METHOD	amt	()V	dE	method_8405
 METHOD	amt	()V	dF	method_14062
 METHOD	amt	()I	dz	method_3075
 METHOD	amt	()Z	l	method_3074
-CLASS	amu	net/minecraft/class_3508
+CLASS	amu	net/minecraft/class_3509
 FIELD	amu	Laiz;	a	field_17026
 FIELD	amu	Z	bC	field_17027
 FIELD	amu	Laiv;	b	field_17028
@@ -4260,15 +4260,15 @@ METHOD	amu	()Z	dD	method_15854
 METHOD	amu	()Z	dF	method_15855
 METHOD	amu	()Z	dI	method_15856
 METHOD	amu	(Lafa;)Z	f	method_15857
-CLASS	amu$a	net/minecraft/class_3508$class_3509
+CLASS	amu$a	net/minecraft/class_3509$class_3510
 FIELD	amu$a	Lamu;	d	field_17029
-CLASS	amu$b	net/minecraft/class_3508$class_3510
+CLASS	amu$b	net/minecraft/class_3509$class_3511
 FIELD	amu$b	Lamu;	a	field_17030
 METHOD	amu$b	(Laog;)Z	a	method_15858
 METHOD	amu$b	(Ljava/lang/Object;)Z	test	test
-CLASS	amu$c	net/minecraft/class_3508$class_3511
+CLASS	amu$c	net/minecraft/class_3509$class_3512
 FIELD	amu$c	Lamu;	f	field_17031
-CLASS	amu$d	net/minecraft/class_3508$class_3512
+CLASS	amu$d	net/minecraft/class_3509$class_3513
 FIELD	amu$d	Lafg;	a	field_17032
 FIELD	amu$d	D	b	field_17033
 FIELD	amu$d	D	c	field_17034
@@ -4276,14 +4276,14 @@ FIELD	amu$d	D	d	field_17035
 FIELD	amu$d	D	e	field_17036
 FIELD	amu$d	Laxy;	f	field_17037
 METHOD	amu$d	()Lcee;	g	method_15859
-CLASS	amu$e	net/minecraft/class_3508$class_3513
+CLASS	amu$e	net/minecraft/class_3509$class_3514
 FIELD	amu$e	Lamu;	i	field_17038
-CLASS	amu$f	net/minecraft/class_3508$class_3514
+CLASS	amu$f	net/minecraft/class_3509$class_3515
 FIELD	amu$f	Lamu;	a	field_17039
 FIELD	amu$f	D	b	field_17040
 FIELD	amu$f	I	c	field_17041
 FIELD	amu$f	Z	d	field_17042
-CLASS	amu$g	net/minecraft/class_3508$class_3515
+CLASS	amu$g	net/minecraft/class_3509$class_3516
 FIELD	amu$g	Lamu;	a	field_17043
 CLASS	amv	net/minecraft/class_3147
 METHOD	amv	(Ltf;)Z	d	method_15860
@@ -4361,7 +4361,7 @@ METHOD	an$a	()Z	a	method_14227
 METHOD	an$a	(Ls$a;)V	a	method_14229
 METHOD	an$a	(Ltf;Laea;FFZ)V	a	method_14228
 METHOD	an$a	(Ls$a;)V	b	method_14230
-CLASS	an$b	net/minecraft/class_3184$class_3516
+CLASS	an$b	net/minecraft/class_3184$class_3517
 FIELD	an$b	Lag;	a	field_17047
 METHOD	an$b	(Lag$a;)Lan$b;	a	method_15866
 METHOD	an$b	(Ltf;Laea;FFZ)Z	a	method_15867
@@ -4434,7 +4434,7 @@ CLASS	anf	net/minecraft/class_974
 CLASS	ang	net/minecraft/class_975
 METHOD	ang	()Z	K_	method_3087
 METHOD	ang	(Laog;)Z	c	method_14129
-CLASS	anh	net/minecraft/class_3517
+CLASS	anh	net/minecraft/class_3518
 FIELD	anh	Lor;	a	field_17048
 FIELD	anh	Lanh$a;	bC	field_17049
 FIELD	anh	Lcee;	b	field_17050
@@ -4460,39 +4460,39 @@ METHOD	anh	(Lanh;)Ljava/util/Random;	l	method_15885
 METHOD	anh	(Lanh;)Ljava/util/Random;	m	method_15886
 METHOD	anh	(Lanh;)Ljava/util/Random;	n	method_15887
 METHOD	anh	(Lanh;)Ljava/util/Random;	o	method_15888
-CLASS	anh$1	net/minecraft/class_3517$1
-CLASS	anh$a	net/minecraft/class_3517$class_3518
+CLASS	anh$1	net/minecraft/class_3518$1
+CLASS	anh$a	net/minecraft/class_3518$class_3519
 FIELD	anh$a	Lanh$a;	a	field_17052
 FIELD	anh$a	Lanh$a;	b	field_17053
 FIELD	anh$a	[Lanh$a;	c	field_17054
 METHOD	anh$a	(Ljava/lang/String;)Lanh$a;	valueOf	valueOf
 METHOD	anh$a	()[Lanh$a;	values	values
-CLASS	anh$b	net/minecraft/class_3517$class_3519
+CLASS	anh$b	net/minecraft/class_3518$class_3520
 FIELD	anh$b	Lanh;	a	field_17055
 FIELD	anh$b	I	b	field_17056
 METHOD	anh$b	(Laog;Laog;)I	a	method_15889
-CLASS	anh$c	net/minecraft/class_3517$class_3520
+CLASS	anh$c	net/minecraft/class_3518$class_3521
 FIELD	anh$c	Lanh;	a	field_17057
 FIELD	anh$c	I	b	field_17058
 METHOD	anh$c	()V	g	method_15890
-CLASS	anh$d	net/minecraft/class_3517$class_3521
+CLASS	anh$d	net/minecraft/class_3518$class_3522
 FIELD	anh$d	Lanh;	a	field_17059
-CLASS	anh$e	net/minecraft/class_3517$class_3522
+CLASS	anh$e	net/minecraft/class_3518$class_3523
 FIELD	anh$e	Lanh;	a	field_17060
 FIELD	anh$e	F	c	field_17061
 FIELD	anh$e	F	d	field_17062
 FIELD	anh$e	F	e	field_17063
 FIELD	anh$e	F	f	field_17064
 METHOD	anh$e	()V	i	method_15891
-CLASS	anh$f	net/minecraft/class_3517$class_3523
+CLASS	anh$f	net/minecraft/class_3518$class_3524
 FIELD	anh$f	Lanh;	h	field_17065
-CLASS	anh$g	net/minecraft/class_3517$class_3524
+CLASS	anh$g	net/minecraft/class_3518$class_3525
 FIELD	anh$g	Lanh;	i	field_17066
 FIELD	anh$g	F	j	field_17067
-CLASS	anh$h	net/minecraft/class_3517$class_3525
+CLASS	anh$h	net/minecraft/class_3518$class_3526
 FIELD	anh$h	Lanh;	b	field_17068
 METHOD	anh$h	()Z	g	method_15892
-CLASS	anh$i	net/minecraft/class_3517$class_3526
+CLASS	anh$i	net/minecraft/class_3518$class_3527
 FIELD	anh$i	Lanh;	a	field_17069
 CLASS	ani	net/minecraft/class_976
 FIELD	ani	Ljava/util/UUID;	a	field_6914
@@ -4745,7 +4745,7 @@ METHOD	anw	(Z)V	u	method_4559
 METHOD	anw	(F)V	v	method_8414
 METHOD	anw	(Z)V	v	method_8417
 CLASS	anw$1	net/minecraft/class_982$1
-CLASS	anw$a	net/minecraft/class_982$class_3527
+CLASS	anw$a	net/minecraft/class_982$class_3528
 FIELD	anw$a	Lanw;	f	field_17074
 CLASS	anw$b	net/minecraft/class_982$class_1718
 FIELD	anw$b	Z	a	field_15074
@@ -4766,7 +4766,7 @@ FIELD	anz	Laqn;	a	field_3942
 FIELD	anz	Laog;	b	field_3943
 FIELD	anz	Laxf;	c	field_3944
 FIELD	anz	Lij;	d	field_12105
-CLASS	ao	net/minecraft/class_3528
+CLASS	ao	net/minecraft/class_3529
 FIELD	ao	Lao;	a	field_17075
 FIELD	ao	[Lao;	b	field_17076
 FIELD	ao	Lap;	c	field_17077
@@ -4779,8 +4779,8 @@ METHOD	ao	(Lcom/google/gson/JsonElement;)Lao;	a	method_15905
 METHOD	ao	(Ltf;Laer;)Z	a	method_15906
 METHOD	ao	([Lao;)Lcom/google/gson/JsonElement;	a	method_15907
 METHOD	ao	(Lcom/google/gson/JsonElement;)[Lao;	b	method_15908
-CLASS	ao$1	net/minecraft/class_3528$1
-CLASS	ao$a	net/minecraft/class_3528$class_3529
+CLASS	ao$1	net/minecraft/class_3529$1
+CLASS	ao$a	net/minecraft/class_3529$class_3530
 FIELD	ao$a	Lap;	a	field_17082
 FIELD	ao$a	Lai;	b	field_17083
 FIELD	ao$a	Lay;	c	field_17084
@@ -5301,7 +5301,7 @@ METHOD	aoz	(Laer;FFFFF)V	a	method_13290
 METHOD	aoz	(Lceb;)V	a	method_3232
 METHOD	aoz	()F	f	method_3236
 METHOD	aoz	()Lafa;	i	method_4585
-CLASS	ap	net/minecraft/class_3530
+CLASS	ap	net/minecraft/class_3531
 FIELD	ap	Lap;	a	field_17099
 FIELD	ap	Lcom/google/common/base/Joiner;	b	field_17100
 FIELD	ap	Laev;	c	field_17101
@@ -5324,7 +5324,7 @@ METHOD	apd	(Late;)V	b	method_11315
 METHOD	apd	()Late;	k	method_11317
 METHOD	apd	()V	l	method_13634
 METHOD	apd	()Z	m	method_11318
-CLASS	ape	net/minecraft/class_3531
+CLASS	ape	net/minecraft/class_3532
 FIELD	ape	Late;	aw	field_17103
 FIELD	ape	Z	ax	field_17104
 FIELD	ape	I	g	field_17105
@@ -5500,7 +5500,7 @@ FIELD	apm	I	d	field_9124
 METHOD	apm	()Laxh;	f	method_8402
 METHOD	apm	()Lor;	i	method_11345
 METHOD	apm	()Lor;	k	method_11346
-CLASS	apm$a	net/minecraft/class_2155$class_3532
+CLASS	apm$a	net/minecraft/class_2155$class_3533
 FIELD	apm$a	Lapm;	a	field_9125
 METHOD	apm$a	()Lapm;	g	method_15964
 CLASS	apn	net/minecraft/class_1575
@@ -5633,20 +5633,20 @@ CLASS	apz	net/minecraft/class_1008
 FIELD	apz	Lade;	a	field_4097
 FIELD	apz	I	f	field_4098
 METHOD	apz	()Lade;	d	method_4591
-CLASS	aq	net/minecraft/class_3533
+CLASS	aq	net/minecraft/class_3534
 FIELD	aq	Lpc;	a	field_17125
 FIELD	aq	Ljava/util/Map;	b	field_17126
 METHOD	aq	(Ltf;Late;)V	a	method_15967
 METHOD	aq	()Lpc;	b	method_15968
 METHOD	aq	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Laq$b;	b	method_15969
-CLASS	aq$a	net/minecraft/class_3533$class_3534
+CLASS	aq$a	net/minecraft/class_3534$class_3535
 FIELD	aq$a	Lpm;	a	field_17127
 FIELD	aq$a	Ljava/util/Set;	b	field_17128
 METHOD	aq$a	()Z	a	method_15970
 METHOD	aq$a	(Late;)V	a	method_15971
 METHOD	aq$a	(Ls$a;)V	a	method_15972
 METHOD	aq$a	(Ls$a;)V	b	method_15973
-CLASS	aq$b	net/minecraft/class_3533$class_3535
+CLASS	aq$b	net/minecraft/class_3534$class_3536
 FIELD	aq$b	Lav;	a	field_17129
 METHOD	aq$b	(Late;)Z	a	method_15974
 METHOD	aq$b	(Lav;)Laq$b;	a	method_15975
@@ -5762,7 +5762,7 @@ FIELD	aqq	Lbjt;	a	field_4145
 METHOD	aqq	(Lbjt;)V	a	method_3288
 METHOD	aqq	(Lhe;)V	a	method_3289
 METHOD	aqq	()Lhe;	i	method_3290
-CLASS	aqr	net/minecraft/class_3536
+CLASS	aqr	net/minecraft/class_3537
 METHOD	aqr	(Laoi;)V	a	method_15978
 METHOD	aqr	(Lavk;)Z	a	method_15979
 METHOD	aqr	()V	d	method_15980
@@ -5770,7 +5770,7 @@ METHOD	aqr	()I	e	method_15981
 METHOD	aqr	()I	f	method_15982
 METHOD	aqr	()I	g	method_15983
 METHOD	aqr	()I	h	method_15984
-CLASS	aqs	net/minecraft/class_3537
+CLASS	aqs	net/minecraft/class_3538
 METHOD	aqs	(Lavk;)V	a	method_14210
 METHOD	aqs	(Laxy;Ltf;Lavk;)Z	a	method_15985
 METHOD	aqs	(Laog;)V	d	method_15986
@@ -5808,22 +5808,22 @@ METHOD	aqx	()Late;	d	method_3299
 METHOD	aqx	(Late;)V	d	method_3302
 METHOD	aqx	()Z	e	method_3301
 METHOD	aqx	()V	f	method_3303
-CLASS	aqy	net/minecraft/class_3538
+CLASS	aqy	net/minecraft/class_3539
 METHOD	aqy	(Laoi;)V	a	method_15987
-CLASS	ar	net/minecraft/class_3539
+CLASS	ar	net/minecraft/class_3540
 FIELD	ar	Lpc;	a	field_17132
 FIELD	ar	Ljava/util/Map;	b	field_17133
 METHOD	ar	(Ltf;Late;Lamg;Ljava/util/Collection;)V	a	method_15988
 METHOD	ar	()Lpc;	b	method_15989
 METHOD	ar	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lar$b;	b	method_15990
-CLASS	ar$a	net/minecraft/class_3539$class_3540
+CLASS	ar$a	net/minecraft/class_3540$class_3541
 FIELD	ar$a	Lpm;	a	field_17134
 FIELD	ar$a	Ljava/util/Set;	b	field_17135
 METHOD	ar$a	()Z	a	method_15991
 METHOD	ar$a	(Ls$a;)V	a	method_15992
 METHOD	ar$a	(Ltf;Late;Lamg;Ljava/util/Collection;)V	a	method_15993
 METHOD	ar$a	(Ls$a;)V	b	method_15994
-CLASS	ar$b	net/minecraft/class_3539$class_3541
+CLASS	ar$b	net/minecraft/class_3540$class_3542
 FIELD	ar$b	Lav;	a	field_17136
 FIELD	ar$b	Lao;	b	field_17137
 FIELD	ar$b	Lav;	c	field_17138
@@ -5843,7 +5843,7 @@ METHOD	arb	()Laew;	b	method_11352
 METHOD	arb	()Larc;	d	method_4602
 METHOD	arb	()I	e	method_15997
 CLASS	arb$1	net/minecraft/class_1028$1
-CLASS	arc	net/minecraft/class_3542
+CLASS	arc	net/minecraft/class_3543
 METHOD	arc	()I	a	method_15998
 METHOD	arc	(Laew;)I	a	method_15999
 METHOD	arc	()Lwi;	b	method_16000
@@ -5851,7 +5851,7 @@ METHOD	arc	(Laew;)I	b	method_16001
 METHOD	arc	()Lavh;	c	method_16002
 METHOD	arc	()Ljava/lang/String;	d	method_16003
 METHOD	arc	()F	e	method_16004
-CLASS	ard	net/minecraft/class_3543
+CLASS	ard	net/minecraft/class_3544
 FIELD	ard	Lard;	a	field_17139
 FIELD	ard	Lard;	b	field_17140
 FIELD	ard	Lard;	c	field_17141
@@ -5896,7 +5896,7 @@ METHOD	arj	(Ljava/util/Map;Lata;)V	a	method_16015
 METHOD	arj	(Lark;)Lblc;	b	method_16016
 METHOD	arj	(Lark;Lblc;)Z	b	method_16017
 METHOD	arj	()Lbcs;	d	method_11271
-CLASS	ark	net/minecraft/class_3544
+CLASS	ark	net/minecraft/class_3545
 FIELD	ark	Z	a	field_17155
 FIELD	ark	Lel;	j	field_17156
 METHOD	ark	()Z	b	method_16018
@@ -5905,7 +5905,7 @@ METHOD	ark	()Leq;	d	method_16020
 METHOD	ark	()[Leq;	e	method_16021
 CLASS	arl	net/minecraft/class_1031
 FIELD	arl	Lapj$b;	a	field_12282
-CLASS	arm	net/minecraft/class_3545
+CLASS	arm	net/minecraft/class_3546
 METHOD	arm	(Late;Laxy;Lel;)Z	a	method_16022
 METHOD	arm	(Late;Laxy;Lel;Leq;)Z	a	method_16023
 METHOD	arm	(Laxz;Lel;I)V	a	method_16024
@@ -5937,7 +5937,7 @@ FIELD	aru$1	D	b	field_12286
 FIELD	aru$1	D	c	field_12287
 FIELD	aru$1	J	d	field_12288
 METHOD	aru$1	(Laxy;D)D	a	method_11366
-CLASS	arv	net/minecraft/class_3546
+CLASS	arv	net/minecraft/class_3547
 CLASS	arw	net/minecraft/class_2683
 CLASS	arw$1	net/minecraft/class_2683$1
 FIELD	arw$1	Larw;	a	field_12293
@@ -6004,7 +6004,7 @@ CLASS	ary$6	net/minecraft/class_1041$6
 CLASS	ary$7	net/minecraft/class_1041$7
 CLASS	ary$8	net/minecraft/class_1041$8
 CLASS	ary$9	net/minecraft/class_1041$9
-CLASS	arz	net/minecraft/class_3547
+CLASS	arz	net/minecraft/class_3548
 METHOD	arz	(Laog;Lblc;Laxz;Lel;ZLate;)V	a	method_16035
 METHOD	arz	(Laog;Lij;)V	a	method_16036
 METHOD	arz	(Lblc;Lbmm;)Ljava/lang/String;	a	method_16037
@@ -6020,7 +6020,7 @@ FIELD	asa	Ljava/util/Set;	a	field_6956
 FIELD	asa	F	b	field_4191
 FIELD	asa	F	c	field_6940
 FIELD	asa	F	d	field_12294
-CLASS	asb	net/minecraft/class_3548
+CLASS	asb	net/minecraft/class_3549
 CLASS	asc	net/minecraft/class_2674
 FIELD	asc	Lasc;	a	field_12157
 FIELD	asc	Lasc;	b	field_12158
@@ -6068,7 +6068,7 @@ FIELD	asd	Ljava/util/Map;	a	field_17167
 FIELD	asd	Lasc;	b	field_17168
 METHOD	asd	(Lasc;)Lasd;	a	method_16046
 METHOD	asd	()Lasc;	d	method_16047
-CLASS	ase	net/minecraft/class_3549
+CLASS	ase	net/minecraft/class_3550
 METHOD	ase	(Late;I)V	a	method_16048
 METHOD	ase	(Late;)Z	e	method_16049
 METHOD	ase	(Late;)I	f	method_16050
@@ -6082,14 +6082,14 @@ CLASS	asi	net/minecraft/class_1428
 METHOD	asi	(Late;Lawh;)V	a	method_4607
 METHOD	asi	(Lawh;)Late;	a	method_4609
 METHOD	asi	(Late;)Lhe;	e	method_4611
-CLASS	asj	net/minecraft/class_3550
+CLASS	asj	net/minecraft/class_3551
 CLASS	ask	net/minecraft/class_2685
 CLASS	asl	net/minecraft/class_1058
 CLASS	asm	net/minecraft/class_1059
 CLASS	asn	net/minecraft/class_1060
 CLASS	aso	net/minecraft/class_1062
 CLASS	asp	net/minecraft/class_1430
-CLASS	asp$a	net/minecraft/class_1430$class_3551
+CLASS	asp$a	net/minecraft/class_1430$class_3552
 FIELD	asp$a	Lasp$a;	a	field_17169
 FIELD	asp$a	Lasp$a;	b	field_17170
 FIELD	asp$a	Lasp$a;	c	field_17171
@@ -6110,7 +6110,7 @@ CLASS	asq	net/minecraft/class_1429
 METHOD	asq	(I)Lij;	a	method_16058
 METHOD	asq	(Lgy;Ljava/util/List;)V	a	method_16059
 METHOD	asq	(Lij;[I)Lij;	a	method_16060
-CLASS	asr	net/minecraft/class_3552
+CLASS	asr	net/minecraft/class_3553
 FIELD	asr	Laev;	a	field_17178
 METHOD	asr	(Laxy;Late;Lel;)V	b	method_16061
 CLASS	ass	net/minecraft/class_1732
@@ -6155,7 +6155,7 @@ METHOD	asv	()Lasv;	e	method_3340
 METHOD	asv	(Late;)I	e	method_6360
 METHOD	asv	()Lasv;	f	method_16065
 METHOD	asv	(Late;)F	f	method_6361
-CLASS	asw	net/minecraft/class_3553
+CLASS	asw	net/minecraft/class_3554
 CLASS	asx	net/minecraft/class_1066
 CLASS	asy	net/minecraft/class_1431
 FIELD	asy	Ljava/lang/Class;	a	field_5429
@@ -6177,7 +6177,7 @@ METHOD	at$a	()Z	a	method_14279
 METHOD	at$a	(Laof;)V	a	method_14280
 METHOD	at$a	(Ls$a;)V	a	method_14281
 METHOD	at$a	(Ls$a;)V	b	method_14282
-CLASS	at$b	net/minecraft/class_3194$class_3554
+CLASS	at$b	net/minecraft/class_3194$class_3555
 FIELD	at$b	Lba$d;	a	field_17186
 FIELD	at$b	Lba$d;	b	field_17187
 FIELD	at$b	Lba$d;	c	field_17188
@@ -6260,7 +6260,7 @@ METHOD	ata	()V	r	method_6368
 METHOD	ata	()Late;	s	method_13650
 CLASS	ata$1	net/minecraft/class_1069$1
 FIELD	ata$1	[I	a	field_17193
-CLASS	ata$a	net/minecraft/class_1069$class_3555
+CLASS	ata$a	net/minecraft/class_1069$class_3556
 FIELD	ata$a	I	a	field_17194
 FIELD	ata$a	I	b	field_17195
 FIELD	ata$a	Lata;	c	field_17196
@@ -6295,7 +6295,7 @@ FIELD	atb$a	I	b	field_17199
 FIELD	atb$a	I	c	field_17200
 METHOD	atb$a	(Latb$a;)I	a	method_16094
 METHOD	atb$a	(Latb$a;)I	b	method_16095
-CLASS	atc	net/minecraft/class_3556
+CLASS	atc	net/minecraft/class_3557
 CLASS	atd	net/minecraft/class_2688
 METHOD	atd	(Late;Laxy;Lafa;)F	call	call
 CLASS	ate	net/minecraft/class_1071
@@ -6781,7 +6781,7 @@ METHOD	au$a	()Z	a	method_14287
 METHOD	au$a	(Late;I)V	a	method_14288
 METHOD	au$a	(Ls$a;)V	a	method_14289
 METHOD	au$a	(Ls$a;)V	b	method_14290
-CLASS	au$b	net/minecraft/class_3197$class_3557
+CLASS	au$b	net/minecraft/class_3197$class_3558
 FIELD	au$b	Lav;	a	field_17377
 FIELD	au$b	Lba$d;	b	field_17378
 FIELD	au$b	Lba$d;	c	field_17379
@@ -6789,7 +6789,7 @@ METHOD	au$b	(Late;I)Z	a	method_16123
 METHOD	au$b	(Lav;Lba$d;)Lau$b;	a	method_16124
 CLASS	aua	net/minecraft/class_1077
 CLASS	aub	net/minecraft/class_1093
-CLASS	auc	net/minecraft/class_3558
+CLASS	auc	net/minecraft/class_3559
 FIELD	auc	Ljava/util/Map;	a	field_17380
 FIELD	auc	I	b	field_17381
 FIELD	auc	I	c	field_17382
@@ -6801,24 +6801,24 @@ METHOD	auc	(Lgy;)Laev;	b	method_16128
 METHOD	auc	()Ljava/lang/Iterable;	d	method_16129
 CLASS	aud	net/minecraft/class_2692
 CLASS	aue	net/minecraft/class_2693
-CLASS	auf	net/minecraft/class_3559
+CLASS	auf	net/minecraft/class_3560
 FIELD	auf	Lbcs;	a	field_17384
-CLASS	aug	net/minecraft/class_3560
+CLASS	aug	net/minecraft/class_3561
 CLASS	auh	net/minecraft/class_1101
 FIELD	auh	F	a	field_6950
 FIELD	auh	F	b	field_17385
 METHOD	auh	()F	d	method_16130
-CLASS	aui	net/minecraft/class_3561
+CLASS	aui	net/minecraft/class_3562
 METHOD	aui	()I	a	method_16131
 METHOD	aui	()F	b	method_16132
 METHOD	aui	()F	c	method_16133
 METHOD	aui	()I	d	method_16134
 METHOD	aui	()I	e	method_16135
 METHOD	aui	()Lavh;	f	method_16136
-CLASS	auj	net/minecraft/class_3562
+CLASS	auj	net/minecraft/class_3563
 FIELD	auj	Laui;	a	field_17386
 METHOD	auj	()Laui;	e	method_16137
-CLASS	auk	net/minecraft/class_3563
+CLASS	auk	net/minecraft/class_3564
 FIELD	auk	Lauk;	a	field_17387
 FIELD	auk	Lauk;	b	field_17388
 FIELD	auk	Lauk;	c	field_17389
@@ -6848,7 +6848,7 @@ FIELD	aum$a	Z	c	field_15677
 FIELD	aum$a	[Laum$a;	d	field_15678
 METHOD	aum$a	(Ljava/lang/String;)Laum$a;	valueOf	valueOf
 METHOD	aum$a	()[Laum$a;	values	values
-CLASS	aun	net/minecraft/class_3564
+CLASS	aun	net/minecraft/class_3565
 METHOD	aun	(Late;Laxy;Lafa;)F	b	method_16143
 CLASS	auo	net/minecraft/class_1099
 FIELD	auo	Lauo;	a	field_9156
@@ -6860,7 +6860,7 @@ FIELD	auo	Lauo;	f	field_17399
 FIELD	auo	[Lauo;	g	field_4409
 METHOD	auo	(Ljava/lang/String;)Lauo;	valueOf	valueOf
 METHOD	auo	()[Lauo;	values	values
-CLASS	aup	net/minecraft/class_3565
+CLASS	aup	net/minecraft/class_3566
 FIELD	aup	Laog;	b	field_17400
 FIELD	aup	F	c	field_17401
 FIELD	aup	F	d	field_17402
@@ -6896,7 +6896,7 @@ METHOD	aut	(Ljava/lang/String;Laut;)V	a	method_11412
 METHOD	aut	()V	b	method_11413
 METHOD	aut	(Ljava/lang/String;)Ljava/lang/String;	b	method_11414
 METHOD	aut	()Z	c	method_11415
-CLASS	auu	net/minecraft/class_3566
+CLASS	auu	net/minecraft/class_3567
 FIELD	auu	Ljava/util/List;	a	field_17408
 FIELD	auu	Ljava/util/List;	b	field_17409
 FIELD	auu	Ljava/util/List;	c	field_17410
@@ -6913,7 +6913,7 @@ METHOD	auu	(Late;)Z	c	method_16163
 METHOD	auu	(Late;Late;)Z	c	method_16164
 METHOD	auu	(Late;)Z	d	method_16165
 METHOD	auu	(Late;Late;)Late;	d	method_16166
-CLASS	auu$a	net/minecraft/class_3566$class_3567
+CLASS	auu$a	net/minecraft/class_3567$class_3568
 FIELD	auu$a	Ljava/lang/Object;	a	field_17412
 FIELD	auu$a	Lavh;	b	field_17413
 FIELD	auu$a	Ljava/lang/Object;	c	field_17414
@@ -6994,7 +6994,7 @@ METHOD	av	()Lcom/google/gson/JsonElement;	a	method_16170
 METHOD	av	(Late;)Z	a	method_14294
 METHOD	av	(Lcom/google/gson/JsonElement;)Lav;	a	method_16171
 METHOD	av	(Lcom/google/gson/JsonElement;)[Lav;	b	method_14296
-CLASS	av$a	net/minecraft/class_3200$class_3568
+CLASS	av$a	net/minecraft/class_3200$class_3569
 FIELD	av$a	Ljava/util/List;	a	field_17422
 FIELD	av$a	Lata;	b	field_17423
 FIELD	av$a	Lwz;	c	field_17424
@@ -7007,19 +7007,19 @@ METHOD	av$a	(Laxx;)Lav$a;	a	method_16173
 METHOD	av$a	(Lba$d;)Lav$a;	a	method_16174
 METHOD	av$a	(Lwz;)Lav$a;	a	method_16175
 METHOD	av$a	()Lav;	b	method_16176
-CLASS	ava	net/minecraft/class_3569
+CLASS	ava	net/minecraft/class_3570
 METHOD	ava	(Lade;)Lbjf;	c	method_16177
-CLASS	avb	net/minecraft/class_3570
+CLASS	avb	net/minecraft/class_3571
 CLASS	avc	net/minecraft/class_1736
-CLASS	avd	net/minecraft/class_3571
+CLASS	avd	net/minecraft/class_3572
 FIELD	avd	Lpc;	a	field_17429
-CLASS	ave	net/minecraft/class_3572
+CLASS	ave	net/minecraft/class_3573
 FIELD	ave	Lavh;	a	field_17430
 FIELD	ave	Lavh;	b	field_17431
 FIELD	ave	Lavh;	c	field_17432
-CLASS	avf	net/minecraft/class_3573
+CLASS	avf	net/minecraft/class_3574
 FIELD	avf	Lavh;	a	field_17433
-CLASS	avg	net/minecraft/class_3574
+CLASS	avg	net/minecraft/class_3575
 FIELD	avg	Lavh;	a	field_17434
 FIELD	avg	Lavh;	b	field_17435
 FIELD	avg	Lavh;	c	field_17436
@@ -7056,11 +7056,11 @@ METHOD	avh	()Z	d	method_16196
 METHOD	avh	()V	f	method_16197
 METHOD	avh	(Ljava/lang/Object;)Z	test	test
 CLASS	avh$1	net/minecraft/class_3193$1
-CLASS	avh$a	net/minecraft/class_3193$class_3575
+CLASS	avh$a	net/minecraft/class_3193$class_3576
 FIELD	avh$a	Late;	a	field_17441
-CLASS	avh$b	net/minecraft/class_3193$class_3576
+CLASS	avh$b	net/minecraft/class_3193$class_3577
 FIELD	avh$b	Lwz;	a	field_17442
-CLASS	avh$c	net/minecraft/class_3193$class_3577
+CLASS	avh$c	net/minecraft/class_3193$class_3578
 METHOD	avh$c	()Ljava/util/Collection;	a	method_16198
 METHOD	avh$c	()Lcom/google/gson/JsonObject;	b	method_16199
 CLASS	avi	net/minecraft/class_1436
@@ -7092,12 +7092,12 @@ METHOD	avl	(Lade;Laxy;)Lavk;	b	method_16209
 METHOD	avl	()Ljava/util/Collection;	c	method_16210
 METHOD	avl	(Lade;Laxy;)Lez;	c	method_16211
 METHOD	avl	()V	d	method_16212
-CLASS	avm	net/minecraft/class_3578
+CLASS	avm	net/minecraft/class_3579
 METHOD	avm	()Ljava/lang/String;	a	method_16213
 METHOD	avm	(Lhy;Lavk;)V	a	method_16214
 METHOD	avm	(Lpc;Lcom/google/gson/JsonObject;)Lavk;	a	method_16215
 METHOD	avm	(Lpc;Lhy;)Lavk;	a	method_16216
-CLASS	avn	net/minecraft/class_3579
+CLASS	avn	net/minecraft/class_3580
 FIELD	avn	Lavm;	a	field_17447
 FIELD	avn	Lavm;	b	field_17448
 FIELD	avn	Lavn$a;	c	field_17449
@@ -7119,7 +7119,7 @@ METHOD	avn	(Lavk;Lhy;)V	a	method_16217
 METHOD	avn	(Lavm;)Lavm;	a	method_16218
 METHOD	avn	(Lhy;)Lavk;	a	method_16219
 METHOD	avn	(Lpc;Lcom/google/gson/JsonObject;)Lavk;	a	method_16220
-CLASS	avn$a	net/minecraft/class_3579$class_3580
+CLASS	avn$a	net/minecraft/class_3580$class_3581
 FIELD	avn$a	Ljava/lang/String;	a	field_17464
 FIELD	avn$a	Ljava/util/function/Function;	b	field_17465
 CLASS	avo	net/minecraft/class_2161
@@ -7148,7 +7148,7 @@ METHOD	avp	(Lavp;)Lez;	d	method_16228
 METHOD	avp	(Lavp;)Late;	e	method_16229
 METHOD	avp	()I	g	method_14272
 METHOD	avp	()I	h	method_14273
-CLASS	avp$a	net/minecraft/class_1115$class_3581
+CLASS	avp$a	net/minecraft/class_1115$class_3582
 METHOD	avp$a	(Lhy;Lavp;)V	a	method_16230
 METHOD	avp$a	(Lpc;Lcom/google/gson/JsonObject;)Lavp;	b	method_16231
 METHOD	avp$a	(Lpc;Lhy;)Lavp;	b	method_16232
@@ -7160,14 +7160,14 @@ FIELD	avq	Lez;	d	field_15688
 METHOD	avq	(Lavq;)Ljava/lang/String;	a	method_16233
 METHOD	avq	(Lavq;)Lez;	b	method_16234
 METHOD	avq	(Lavq;)Late;	c	method_16235
-CLASS	avq$a	net/minecraft/class_1116$class_3582
+CLASS	avq$a	net/minecraft/class_1116$class_3583
 METHOD	avq$a	(Lcom/google/gson/JsonArray;)Lez;	a	method_16236
 METHOD	avq$a	(Lhy;Lavq;)V	a	method_16237
 METHOD	avq$a	(Lpc;Lcom/google/gson/JsonObject;)Lavq;	b	method_16238
 METHOD	avq$a	(Lpc;Lhy;)Lavq;	b	method_16239
 CLASS	avr	net/minecraft/class_2700
-CLASS	avs	net/minecraft/class_3583
-CLASS	avt	net/minecraft/class_3584
+CLASS	avs	net/minecraft/class_3584
+CLASS	avt	net/minecraft/class_3585
 FIELD	avt	Lpc;	a	field_17468
 FIELD	avt	Ljava/lang/String;	b	field_17469
 FIELD	avt	Lavh;	c	field_17470
@@ -7181,7 +7181,7 @@ METHOD	avt	(Lavt;)F	d	method_16243
 METHOD	avt	(Lavt;)I	e	method_16244
 METHOD	avt	()F	g	method_16245
 METHOD	avt	()I	h	method_16246
-CLASS	avt$a	net/minecraft/class_3584$class_3585
+CLASS	avt$a	net/minecraft/class_3585$class_3586
 METHOD	avt$a	(Lhy;Lavt;)V	a	method_16247
 METHOD	avt$a	(Lpc;Lcom/google/gson/JsonObject;)Lavt;	b	method_16248
 METHOD	avt$a	(Lpc;Lhy;)Lavt;	b	method_16249
@@ -7203,7 +7203,7 @@ METHOD	aw$a	()Z	a	method_14299
 METHOD	aw$a	(Ls$a;)V	a	method_14301
 METHOD	aw$a	(Ltf;Laer;Laea;)V	a	method_14300
 METHOD	aw$a	(Ls$a;)V	b	method_14302
-CLASS	aw$b	net/minecraft/class_3201$class_3586
+CLASS	aw$b	net/minecraft/class_3201$class_3587
 FIELD	aw$b	Lao;	a	field_17474
 FIELD	aw$b	Lah;	b	field_17475
 METHOD	aw$b	(Lao$a;)Law$b;	a	method_16251
@@ -7398,10 +7398,10 @@ METHOD	awr	(I)F	e	method_13681
 CLASS	aws	net/minecraft/class_1438
 METHOD	aws	(ILjava/util/Random;)Z	a	method_4660
 METHOD	aws	(ILjava/util/Random;)I	b	method_4662
-CLASS	awt	net/minecraft/class_3587
-CLASS	awu	net/minecraft/class_3588
-CLASS	awv	net/minecraft/class_3589
-CLASS	aww	net/minecraft/class_3590
+CLASS	awt	net/minecraft/class_3588
+CLASS	awu	net/minecraft/class_3589
+CLASS	awv	net/minecraft/class_3590
+CLASS	aww	net/minecraft/class_3591
 CLASS	awx	net/minecraft/class_1141
 CLASS	awy	net/minecraft/class_3063
 CLASS	awz	net/minecraft/class_2163
@@ -7418,7 +7418,7 @@ METHOD	ax$a	()Z	a	method_14313
 METHOD	ax$a	(Ls$a;)V	a	method_14315
 METHOD	ax$a	(Ltf;Lcee;I)V	a	method_14314
 METHOD	ax$a	(Ls$a;)V	b	method_14316
-CLASS	ax$b	net/minecraft/class_3204$class_3591
+CLASS	ax$b	net/minecraft/class_3204$class_3592
 FIELD	ax$b	Lai;	a	field_17482
 FIELD	ax$b	Lba$d;	b	field_17483
 METHOD	ax$b	(Lai;)Lax$b;	a	method_16269
@@ -7562,17 +7562,17 @@ METHOD	axm	()I	g	method_8471
 METHOD	axm	()Lel;	h	method_16284
 METHOD	axm	()I	hashCode	hashCode
 METHOD	axm	()Ljava/lang/String;	toString	toString
-CLASS	axo	net/minecraft/class_3592
+CLASS	axo	net/minecraft/class_3593
 FIELD	axo	Laxo;	a	field_17486
 METHOD	axo	()Laxo;	a	method_16285
-CLASS	axp	net/minecraft/class_3593
+CLASS	axp	net/minecraft/class_3594
 METHOD	axp	(Laer;Lcea;)Ljava/util/List;	a	method_16286
 METHOD	axp	(Laer;Lcea;Laer;)Ljava/util/stream/Stream;	a	method_16287
 METHOD	axp	(Laer;Lcea;Ljava/util/function/Predicate;)Ljava/util/List;	a	method_16288
 METHOD	axp	(Laer;Lcew;Ljava/util/Set;)Ljava/util/stream/Stream;	a	method_16289
 METHOD	axp	(Lcea;Lcea;)Z	a	method_16290
 METHOD	axp	(Ljava/util/Set;Laer;Laer;)Z	a	method_16291
-CLASS	axq	net/minecraft/class_3594
+CLASS	axq	net/minecraft/class_3595
 FIELD	axq	I	a	field_17487
 FIELD	axq	Lit/unimi/dsi/fastutil/longs/Long2LongMap;	b	field_17488
 METHOD	axq	(J)V	a	method_16292
@@ -7612,7 +7612,7 @@ METHOD	axs	(DD)I	a	method_3571
 METHOD	axs	([I)V	a	method_3572
 METHOD	axs	()I	b	method_3573
 METHOD	axs	()I	c	method_3574
-CLASS	axt	net/minecraft/class_3595
+CLASS	axt	net/minecraft/class_3596
 FIELD	axt	Lit/unimi/dsi/fastutil/longs/LongSet;	a	field_17490
 METHOD	axt	()Lit/unimi/dsi/fastutil/longs/LongSet;	a	method_16296
 CLASS	axu	net/minecraft/class_1439
@@ -7639,7 +7639,7 @@ METHOD	axu$a	(Ljava/lang/String;Lnet/minecraft/server/MinecraftServer;)V	a	metho
 METHOD	axu$a	()Z	b	method_4677
 METHOD	axu$a	()I	c	method_8476
 METHOD	axu$a	()Laxu$c;	e	method_8477
-CLASS	axu$b	net/minecraft/class_1439$class_3596
+CLASS	axu$b	net/minecraft/class_1439$class_3597
 FIELD	axu$b	Laxu$c;	a	field_17493
 FIELD	axu$b	Ljava/lang/String;	b	field_17494
 FIELD	axu$b	Ljava/util/function/BiConsumer;	c	field_17495
@@ -7686,7 +7686,7 @@ CLASS	axw	net/minecraft/class_1149
 FIELD	axw	[I	a	field_4521
 METHOD	axw	(DD)I	a	method_3575
 METHOD	axw	([I)V	a	method_3576
-CLASS	axx	net/minecraft/class_3597
+CLASS	axx	net/minecraft/class_3598
 METHOD	axx	()Lata;	h	method_16312
 CLASS	axy	net/minecraft/class_1150
 FIELD	axy	Lxr;	A	field_4527
@@ -7881,7 +7881,7 @@ METHOD	axy	()V	w	method_3722
 METHOD	axy	(Lel;)Z	w	method_8480
 METHOD	axy	(Lel;)Z	x	method_8481
 METHOD	axy	()Lnet/minecraft/server/MinecraftServer;	z	method_2146
-CLASS	axz	net/minecraft/class_3598
+CLASS	axz	net/minecraft/class_3599
 METHOD	axz	()Lbnc;	H	method_3586
 METHOD	axz	()Layo;	I	method_16340
 METHOD	axz	()Layo;	J	method_16341
@@ -7930,7 +7930,7 @@ METHOD	ayb	(Lfk;ZZDDDDDD)V	a	method_13696
 METHOD	ayb	(Lwi;Lel;)V	a	method_8572
 METHOD	ayb	(ILel;I)V	b	method_8573
 METHOD	ayb	(Laer;)V	b	method_3752
-CLASS	ayc	net/minecraft/class_3599
+CLASS	ayc	net/minecraft/class_3600
 METHOD	ayc	(Lel;)F	A	method_16356
 METHOD	ayc	(Lel;)Z	B	method_16357
 METHOD	ayc	(Lel;)I	C	method_16358
@@ -7999,9 +7999,9 @@ METHOD	ayd	()Z	g	method_3760
 METHOD	ayd	()Layg;	h	method_3761
 METHOD	ayd	()Z	i	method_3762
 METHOD	ayd	()Lcom/google/gson/JsonElement;	j	method_4695
-CLASS	aye	net/minecraft/class_3600
+CLASS	aye	net/minecraft/class_3601
 METHOD	aye	(Lel;I)I	b	method_8578
-CLASS	ayf	net/minecraft/class_3601
+CLASS	ayf	net/minecraft/class_3602
 METHOD	ayf	(Lbod;Ljava/lang/String;)I	a	method_16396
 METHOD	ayf	(Lbod;Ljava/lang/String;Lcbo;)V	a	method_16397
 METHOD	ayf	(Lbod;Ljava/util/function/Function;Ljava/lang/String;)Lcbo;	a	method_16398
@@ -8040,7 +8040,7 @@ METHOD	ayg	()I	i	method_4697
 METHOD	ayg	()Z	j	method_6415
 METHOD	ayg	()Layg;	k	method_3795
 METHOD	ayg	()Layg;	l	method_6416
-CLASS	ayh	net/minecraft/class_3602
+CLASS	ayh	net/minecraft/class_3603
 METHOD	ayh	(Laer;)Z	a	method_3686
 METHOD	ayh	(Layi;Lel;I)V	a	method_16403
 METHOD	ayh	(Lel;Lblc;I)Z	a	method_8506
@@ -8086,7 +8086,7 @@ FIELD	ayl	Laxy;	e	field_4599
 METHOD	ayl	(II)Z	a	method_16408
 METHOD	ayl	(Lel;Lbnj$a;)Lbji;	a	method_13314
 METHOD	ayl	(Layi;Lel;)I	b	method_8585
-CLASS	aym	net/minecraft/class_3603
+CLASS	aym	net/minecraft/class_3604
 FIELD	aym	Ljava/util/function/Predicate;	a	field_17512
 FIELD	aym	Ljava/util/function/Function;	b	field_17513
 FIELD	aym	Ljava/util/function/Function;	c	field_17514
@@ -8107,7 +8107,7 @@ CLASS	ayn	net/minecraft/class_1587
 FIELD	ayn	Lgy;	b	field_12439
 METHOD	ayn	()Lgy;	a	method_5486
 METHOD	ayn	()Lgy;	b	method_11497
-CLASS	ayo	net/minecraft/class_3604
+CLASS	ayo	net/minecraft/class_3605
 METHOD	ayo	(Lel;Ljava/lang/Object;)Z	a	method_16417
 METHOD	ayo	(Lel;Ljava/lang/Object;I)V	a	method_16418
 METHOD	ayo	(Lel;Ljava/lang/Object;ILayq;)V	a	method_16419
@@ -8125,7 +8125,7 @@ METHOD	ayp	(Ljava/lang/Object;)I	compareTo	compareTo
 METHOD	ayp	(Ljava/lang/Object;)Z	equals	equals
 METHOD	ayp	()I	hashCode	hashCode
 METHOD	ayp	()Ljava/lang/String;	toString	toString
-CLASS	ayq	net/minecraft/class_3605
+CLASS	ayq	net/minecraft/class_3606
 FIELD	ayq	Layq;	a	field_17522
 FIELD	ayq	Layq;	b	field_17523
 FIELD	ayq	Layq;	c	field_17524
@@ -8139,8 +8139,8 @@ METHOD	ayq	()I	a	method_16422
 METHOD	ayq	(I)Layq;	a	method_16423
 METHOD	ayq	(Ljava/lang/String;)Layq;	valueOf	valueOf
 METHOD	ayq	()[Layq;	values	values
-CLASS	ayr	net/minecraft/class_3606
-CLASS	ays	net/minecraft/class_3607
+CLASS	ayr	net/minecraft/class_3607
+CLASS	ays	net/minecraft/class_3608
 CLASS	ayt	net/minecraft/class_1169
 CLASS	ayu	net/minecraft/class_1170
 FIELD	ayu	Lbvg;	A	field_17531
@@ -8293,7 +8293,7 @@ METHOD	ayu	()Lbxr;	q	method_16449
 METHOD	ayu	()Lbye;	r	method_16450
 METHOD	ayu	()Ljava/lang/String;	s	method_16451
 METHOD	ayu	()V	t	method_11510
-CLASS	ayu$a	net/minecraft/class_1170$class_3608
+CLASS	ayu$a	net/minecraft/class_1170$class_3609
 FIELD	ayu$a	Lbxr;	a	field_17625
 FIELD	ayu$a	Layu$d;	b	field_17626
 FIELD	ayu$a	Layu$b;	c	field_17627
@@ -8325,7 +8325,7 @@ METHOD	ayu$a	(Layu$a;)Ljava/lang/Integer;	h	method_16469
 METHOD	ayu$a	(Layu$a;)Ljava/lang/Integer;	i	method_16470
 METHOD	ayu$a	(Layu$a;)Ljava/lang/String;	j	method_16471
 METHOD	ayu$a	()Ljava/lang/String;	toString	toString
-CLASS	ayu$b	net/minecraft/class_1170$class_3609
+CLASS	ayu$b	net/minecraft/class_1170$class_3610
 FIELD	ayu$b	Layu$b;	a	field_17635
 FIELD	ayu$b	Layu$b;	b	field_17636
 FIELD	ayu$b	Layu$b;	c	field_17637
@@ -8354,7 +8354,7 @@ FIELD	ayu$c	Layu$c;	d	field_7225
 FIELD	ayu$c	[Layu$c;	e	field_7226
 METHOD	ayu$c	(Ljava/lang/String;)Layu$c;	valueOf	valueOf
 METHOD	ayu$c	()[Layu$c;	values	values
-CLASS	ayu$d	net/minecraft/class_1170$class_3610
+CLASS	ayu$d	net/minecraft/class_1170$class_3611
 FIELD	ayu$d	Layu$d;	a	field_17653
 FIELD	ayu$d	Layu$d;	b	field_17654
 FIELD	ayu$d	Layu$d;	c	field_17655
@@ -8397,8 +8397,8 @@ METHOD	ayw	(Lel;Layu;)Layu;	a	method_16480
 METHOD	ayw	()Ljava/util/Set;	b	method_16481
 METHOD	ayw	(IIII)[Layu;	b	method_11540
 METHOD	ayw	(IIII)F	c	method_16482
-CLASS	ayx	net/minecraft/class_3611
-CLASS	ayy	net/minecraft/class_3612
+CLASS	ayx	net/minecraft/class_3612
+CLASS	ayy	net/minecraft/class_3613
 FIELD	ayy	Layy;	a	field_17664
 FIELD	ayy	Layy;	b	field_17665
 FIELD	ayy	Layy;	c	field_17666
@@ -8500,52 +8500,52 @@ METHOD	az$a	()Z	a	method_14328
 METHOD	az$a	(Ls$a;)V	a	method_14330
 METHOD	az$a	(Ltd;DDD)V	a	method_14329
 METHOD	az$a	(Ls$a;)V	b	method_14331
-CLASS	az$b	net/minecraft/class_3210$class_3613
+CLASS	az$b	net/minecraft/class_3210$class_3614
 FIELD	az$b	Lay;	a	field_17682
 METHOD	az$b	(Lay;)Laz$b;	a	method_16489
 METHOD	az$b	(Ltd;DDD)Z	a	method_16490
 METHOD	az$b	()Laz$b;	c	method_16491
-CLASS	aza	net/minecraft/class_3614
-CLASS	azb	net/minecraft/class_3615
-CLASS	azc	net/minecraft/class_3616
+CLASS	aza	net/minecraft/class_3615
+CLASS	azb	net/minecraft/class_3616
+CLASS	azc	net/minecraft/class_3617
 FIELD	azc	[Layu;	c	field_17683
 FIELD	azc	I	d	field_17684
 METHOD	azc	(Lbtl;)Ljava/lang/Boolean;	b	method_16492
-CLASS	azd	net/minecraft/class_3617
+CLASS	azd	net/minecraft/class_3618
 FIELD	azd	[Layu;	a	field_17685
 FIELD	azd	I	b	field_17686
 METHOD	azd	()[Layu;	a	method_16493
 METHOD	azd	(I)Lazd;	a	method_16494
 METHOD	azd	([Layu;)Lazd;	a	method_16495
 METHOD	azd	()I	b	method_16496
-CLASS	aze	net/minecraft/class_3618
-CLASS	azf	net/minecraft/class_3619
-CLASS	azg	net/minecraft/class_3620
-CLASS	azh	net/minecraft/class_3621
-CLASS	azi	net/minecraft/class_3622
+CLASS	aze	net/minecraft/class_3619
+CLASS	azf	net/minecraft/class_3620
+CLASS	azg	net/minecraft/class_3621
+CLASS	azh	net/minecraft/class_3622
+CLASS	azi	net/minecraft/class_3623
 FIELD	azi	Lbyk;	aZ	field_17687
-CLASS	azj	net/minecraft/class_3623
-CLASS	azk	net/minecraft/class_3624
-CLASS	azl	net/minecraft/class_3625
+CLASS	azj	net/minecraft/class_3624
+CLASS	azk	net/minecraft/class_3625
+CLASS	azl	net/minecraft/class_3626
 CLASS	azm	net/minecraft/class_1176
-CLASS	azn	net/minecraft/class_3626
-CLASS	azo	net/minecraft/class_3627
-CLASS	azp	net/minecraft/class_3628
-CLASS	azq	net/minecraft/class_3629
-CLASS	azr	net/minecraft/class_3630
-CLASS	azs	net/minecraft/class_3631
-CLASS	azt	net/minecraft/class_3632
+CLASS	azn	net/minecraft/class_3627
+CLASS	azo	net/minecraft/class_3628
+CLASS	azp	net/minecraft/class_3629
+CLASS	azq	net/minecraft/class_3630
+CLASS	azr	net/minecraft/class_3631
+CLASS	azs	net/minecraft/class_3632
+CLASS	azt	net/minecraft/class_3633
 FIELD	azt	Layu;	c	field_17688
-CLASS	azu	net/minecraft/class_3633
+CLASS	azu	net/minecraft/class_3634
 FIELD	azu	Layu;	a	field_17689
 METHOD	azu	()Layu;	a	method_16497
 METHOD	azu	(Layu;)Lazu;	a	method_16498
 CLASS	azv	net/minecraft/class_1179
-CLASS	azw	net/minecraft/class_3634
-CLASS	azx	net/minecraft/class_3635
+CLASS	azw	net/minecraft/class_3635
+CLASS	azx	net/minecraft/class_3636
 FIELD	azx	Lbyk;	aZ	field_17690
-CLASS	azy	net/minecraft/class_3636
-CLASS	azz	net/minecraft/class_3637
+CLASS	azy	net/minecraft/class_3637
+CLASS	azz	net/minecraft/class_3638
 CLASS	b	net/minecraft/class_1
 FIELD	b	Lorg/apache/logging/log4j/Logger;	a	field_7610
 FIELD	b	Ljava/lang/String;	b	field_1
@@ -8574,7 +8574,7 @@ METHOD	b	()Ljava/lang/String;	l	method_16501
 METHOD	b	()Ljava/lang/String;	m	method_16502
 METHOD	b	()Ljava/lang/String;	n	method_16503
 METHOD	b	()Ljava/lang/String;	o	method_16504
-CLASS	ba	net/minecraft/class_3638
+CLASS	ba	net/minecraft/class_3639
 FIELD	ba	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_17691
 FIELD	ba	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_17692
 FIELD	ba	Ljava/lang/Number;	c	field_17693
@@ -8588,11 +8588,11 @@ METHOD	ba	(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;	a	
 METHOD	ba	()Ljava/lang/Number;	b	method_16511
 METHOD	ba	()Z	c	method_16512
 METHOD	ba	()Lcom/google/gson/JsonElement;	d	method_16513
-CLASS	ba$a	net/minecraft/class_3638$class_3639
+CLASS	ba$a	net/minecraft/class_3639$class_3640
 METHOD	ba$a	(Ljava/lang/Number;Ljava/lang/Number;)Lba;	create	create
-CLASS	ba$b	net/minecraft/class_3638$class_3640
+CLASS	ba$b	net/minecraft/class_3639$class_3641
 METHOD	ba$b	(Lcom/mojang/brigadier/StringReader;Ljava/lang/Number;Ljava/lang/Number;)Lba;	create	create
-CLASS	ba$c	net/minecraft/class_3638$class_3641
+CLASS	ba$c	net/minecraft/class_3639$class_3642
 FIELD	ba$c	Lba$c;	e	field_17695
 FIELD	ba$c	Ljava/lang/Double;	f	field_17696
 FIELD	ba$c	Ljava/lang/Double;	g	field_17697
@@ -8605,7 +8605,7 @@ METHOD	ba$c	(Ljava/lang/Float;)Ljava/lang/Double;	a	method_16519
 METHOD	ba$c	(F)Lba$c;	b	method_16520
 METHOD	ba$c	(Ljava/lang/Float;)Ljava/lang/Float;	b	method_16521
 METHOD	ba$c	(F)Z	d	method_16522
-CLASS	ba$d	net/minecraft/class_3638$class_3642
+CLASS	ba$d	net/minecraft/class_3639$class_3643
 FIELD	ba$d	Lba$d;	e	field_17698
 FIELD	ba$d	Ljava/lang/Long;	f	field_17699
 FIELD	ba$d	Ljava/lang/Long;	g	field_17700
@@ -8618,33 +8618,33 @@ METHOD	ba$d	(Ljava/lang/Integer;)Ljava/lang/Long;	a	method_16528
 METHOD	ba$d	(I)Lba$d;	b	method_16529
 METHOD	ba$d	(Ljava/lang/Integer;)Ljava/lang/Integer;	b	method_16530
 METHOD	ba$d	(I)Z	d	method_16531
-CLASS	baa	net/minecraft/class_3643
-CLASS	bab	net/minecraft/class_3644
-CLASS	bac	net/minecraft/class_3645
-CLASS	bad	net/minecraft/class_3646
+CLASS	baa	net/minecraft/class_3644
+CLASS	bab	net/minecraft/class_3645
+CLASS	bac	net/minecraft/class_3646
+CLASS	bad	net/minecraft/class_3647
 CLASS	bae	net/minecraft/class_1181
 CLASS	baf	net/minecraft/class_1182
-CLASS	bag	net/minecraft/class_3647
-CLASS	bah	net/minecraft/class_3648
-CLASS	bai	net/minecraft/class_3649
-CLASS	baj	net/minecraft/class_3650
-CLASS	bak	net/minecraft/class_3651
-CLASS	bal	net/minecraft/class_3652
-CLASS	bam	net/minecraft/class_3653
-CLASS	ban	net/minecraft/class_3654
-CLASS	bao	net/minecraft/class_3655
-CLASS	bap	net/minecraft/class_3656
-CLASS	baq	net/minecraft/class_3657
-CLASS	bar	net/minecraft/class_3658
+CLASS	bag	net/minecraft/class_3648
+CLASS	bah	net/minecraft/class_3649
+CLASS	bai	net/minecraft/class_3650
+CLASS	baj	net/minecraft/class_3651
+CLASS	bak	net/minecraft/class_3652
+CLASS	bal	net/minecraft/class_3653
+CLASS	bam	net/minecraft/class_3654
+CLASS	ban	net/minecraft/class_3655
+CLASS	bao	net/minecraft/class_3656
+CLASS	bap	net/minecraft/class_3657
+CLASS	baq	net/minecraft/class_3658
+CLASS	bar	net/minecraft/class_3659
 CLASS	bas	net/minecraft/class_1180
 CLASS	bat	net/minecraft/class_1184
-CLASS	bau	net/minecraft/class_3659
+CLASS	bau	net/minecraft/class_3660
 FIELD	bau	Layv;	c	field_17701
 FIELD	bau	Lbzx;	d	field_17702
 FIELD	bau	Lbzx;	e	field_17703
 FIELD	bau	[Layu;	f	field_17704
 METHOD	bau	(Lbtl;)Ljava/lang/Boolean;	b	method_16532
-CLASS	bav	net/minecraft/class_3660
+CLASS	bav	net/minecraft/class_3661
 FIELD	bav	Lccb;	a	field_17705
 FIELD	bav	Lbou;	b	field_17706
 METHOD	bav	()Lccb;	a	method_16533
@@ -8654,7 +8654,7 @@ METHOD	bav	()Lbou;	b	method_16536
 CLASS	baw	net/minecraft/class_1185
 CLASS	bax	net/minecraft/class_1187
 CLASS	bay	net/minecraft/class_1748
-CLASS	baz	net/minecraft/class_3661
+CLASS	baz	net/minecraft/class_3662
 CLASS	bb	net/minecraft/class_3214
 FIELD	bb	Lbb;	a	field_15766
 FIELD	bb	Ljava/util/Map;	b	field_15767
@@ -8673,40 +8673,40 @@ FIELD	bb$a	Ljava/lang/Boolean;	d	field_15771
 METHOD	bb$a	()Lcom/google/gson/JsonElement;	a	method_16540
 METHOD	bb$a	(Laek;)Z	a	method_14342
 METHOD	bb$a	(Lcom/google/gson/JsonObject;)Lbb$a;	a	method_14341
-CLASS	bba	net/minecraft/class_3662
-CLASS	bbb	net/minecraft/class_3663
-CLASS	bbc	net/minecraft/class_3664
-CLASS	bbd	net/minecraft/class_3665
-CLASS	bbe	net/minecraft/class_3666
-CLASS	bbf	net/minecraft/class_3667
-CLASS	bbg	net/minecraft/class_3668
-CLASS	bbh	net/minecraft/class_3669
-CLASS	bbi	net/minecraft/class_3670
-CLASS	bbj	net/minecraft/class_3671
-CLASS	bbk	net/minecraft/class_3672
+CLASS	bba	net/minecraft/class_3663
+CLASS	bbb	net/minecraft/class_3664
+CLASS	bbc	net/minecraft/class_3665
+CLASS	bbd	net/minecraft/class_3666
+CLASS	bbe	net/minecraft/class_3667
+CLASS	bbf	net/minecraft/class_3668
+CLASS	bbg	net/minecraft/class_3669
+CLASS	bbh	net/minecraft/class_3670
+CLASS	bbi	net/minecraft/class_3671
+CLASS	bbj	net/minecraft/class_3672
+CLASS	bbk	net/minecraft/class_3673
 CLASS	bbl	net/minecraft/class_1188
-CLASS	bbm	net/minecraft/class_3673
-CLASS	bbn	net/minecraft/class_3674
-CLASS	bbo	net/minecraft/class_3675
-CLASS	bbp	net/minecraft/class_3676
-CLASS	bbq	net/minecraft/class_3677
-CLASS	bbr	net/minecraft/class_3678
+CLASS	bbm	net/minecraft/class_3674
+CLASS	bbn	net/minecraft/class_3675
+CLASS	bbo	net/minecraft/class_3676
+CLASS	bbp	net/minecraft/class_3677
+CLASS	bbq	net/minecraft/class_3678
+CLASS	bbr	net/minecraft/class_3679
 CLASS	bbs	net/minecraft/class_1190
-CLASS	bbt	net/minecraft/class_3679
+CLASS	bbt	net/minecraft/class_3680
 FIELD	bbt	Lbyl;	c	field_17707
 FIELD	bbt	Lboz;	d	field_17708
 FIELD	bbt	[Layu;	e	field_17709
 METHOD	bbt	(II)Layu;	a	method_16541
 METHOD	bbt	(Lbtl;)Ljava/lang/Boolean;	b	method_16542
-CLASS	bbu	net/minecraft/class_3680
+CLASS	bbu	net/minecraft/class_3681
 FIELD	bbu	J	a	field_17710
 METHOD	bbu	()J	a	method_16543
 METHOD	bbu	(J)Lbbu;	a	method_16544
 CLASS	bbv	net/minecraft/class_2716
-CLASS	bbw	net/minecraft/class_3681
-CLASS	bbx	net/minecraft/class_3682
+CLASS	bbw	net/minecraft/class_3682
+CLASS	bbx	net/minecraft/class_3683
 CLASS	bby	net/minecraft/class_1177
-CLASS	bbz	net/minecraft/class_3683
+CLASS	bbz	net/minecraft/class_3684
 CLASS	bc	net/minecraft/class_3216
 FIELD	bc	Lbc;	a	field_15772
 FIELD	bc	Lgy;	b	field_15773
@@ -8716,10 +8716,10 @@ METHOD	bc	(Late;)Z	a	method_14343
 METHOD	bc	(Lcom/google/gson/JsonElement;)Lbc;	a	method_14344
 METHOD	bc	(Lho;)Z	a	method_14345
 METHOD	bc	(Laer;)Lgy;	b	method_16546
-CLASS	bcb	net/minecraft/class_3684
+CLASS	bcb	net/minecraft/class_3685
 FIELD	bcb	Lasc;	a	field_17711
 METHOD	bcb	()Lasc;	b	method_16547
-CLASS	bcc	net/minecraft/class_3685
+CLASS	bcc	net/minecraft/class_3686
 FIELD	bcc	Lbhk$a;	a	field_17712
 METHOD	bcc	()Lbhk$a;	b	method_16548
 CLASS	bcd	net/minecraft/class_1751
@@ -8739,7 +8739,7 @@ METHOD	bce	(Lblc;)Lblc;	a_	method_16549
 CLASS	bce$a	net/minecraft/class_1299$class_2169
 FIELD	bce$a	Laxy;	a	field_9246
 FIELD	bce$a	Lel;	b	field_9247
-CLASS	bcf	net/minecraft/class_3686
+CLASS	bcf	net/minecraft/class_3687
 FIELD	bcf	Lbme;	a	field_17722
 FIELD	bcf	Lbia;	b	field_17723
 FIELD	bcf	Ljava/util/Map;	c	field_17724
@@ -8750,16 +8750,16 @@ FIELD	bcg	Ljava/util/Map;	b	field_17726
 FIELD	bcg	Lcew;	c	field_17727
 METHOD	bcg	(Lasc;)Lbcs;	a	method_16551
 CLASS	bch	net/minecraft/class_2174
-CLASS	bci	net/minecraft/class_3687
+CLASS	bci	net/minecraft/class_3688
 FIELD	bci	Lcew;	a	field_17728
-CLASS	bcj	net/minecraft/class_3688
+CLASS	bcj	net/minecraft/class_3689
 FIELD	bcj	Lcew;	a	field_17729
-CLASS	bck	net/minecraft/class_3689
+CLASS	bck	net/minecraft/class_3690
 FIELD	bck	Lcew;	a	field_17730
 FIELD	bck	Lbmb;	b	field_17731
 METHOD	bck	(Lblc;Laxz;Lel;)V	a	method_16552
 METHOD	bck	(Lblc;Laxk;Lel;)Z	b_	method_16553
-CLASS	bcl	net/minecraft/class_3690
+CLASS	bcl	net/minecraft/class_3691
 FIELD	bcl	Lbme;	a	field_17732
 FIELD	bcl	Ljava/util/Map;	c	field_17733
 CLASS	bcm	net/minecraft/class_133
@@ -8941,7 +8941,7 @@ CLASS	bcs$1	net/minecraft/class_197$1
 METHOD	bcs$1	(I)V	rehash	rehash
 CLASS	bcs$2	net/minecraft/class_197$2
 FIELD	bcs$2	[I	a	field_17750
-CLASS	bcs$a	net/minecraft/class_197$class_3691
+CLASS	bcs$a	net/minecraft/class_197$class_3692
 FIELD	bcs$a	Lblc;	a	field_17751
 FIELD	bcs$a	Lblc;	b	field_17752
 FIELD	bcs$a	Leq;	c	field_17753
@@ -8954,7 +8954,7 @@ FIELD	bcs$b	Lbcs$b;	c	field_9288
 FIELD	bcs$b	[Lbcs$b;	d	field_9289
 METHOD	bcs$b	(Ljava/lang/String;)Lbcs$b;	valueOf	valueOf
 METHOD	bcs$b	()[Lbcs$b;	values	values
-CLASS	bcs$c	net/minecraft/class_197$class_3692
+CLASS	bcs$c	net/minecraft/class_197$class_3693
 FIELD	bcs$c	Lbza;	a	field_17754
 FIELD	bcs$c	Lbzb;	b	field_17755
 FIELD	bcs$c	Z	c	field_17756
@@ -9589,7 +9589,7 @@ FIELD	bct	Lbcs;	x	field_18197
 FIELD	bct	Lbcs;	y	field_18198
 FIELD	bct	Lbcs;	z	field_7426
 METHOD	bct	(Ljava/lang/String;)Lbcs;	a	method_8689
-CLASS	bcu	net/minecraft/class_3693
+CLASS	bcu	net/minecraft/class_3694
 CLASS	bcv	net/minecraft/class_1753
 METHOD	bcv	(Laxk;Lel;Lblc;Z)Z	a	method_6460
 METHOD	bcv	(Laxy;Ljava/util/Random;Lel;Lblc;)Z	a	method_6461
@@ -9598,12 +9598,12 @@ CLASS	bcw	net/minecraft/class_110
 CLASS	bcx	net/minecraft/class_111
 FIELD	bcx	[Lbmb;	a	field_9327
 FIELD	bcx	Lcew;	b	field_18199
-CLASS	bcy	net/minecraft/class_3694
+CLASS	bcy	net/minecraft/class_3695
 FIELD	bcy	Lbmb;	a	field_18200
 METHOD	bcy	(Laxk;Lel;)Z	a	method_16628
 METHOD	bcy	(Laxz;Lel;)Z	a	method_16629
 METHOD	bcy	(Laxz;Lel;Z)V	a	method_16630
-CLASS	bcz	net/minecraft/class_3695
+CLASS	bcz	net/minecraft/class_3696
 METHOD	bcz	(Laxz;Lel;Lblc;)Lbyv;	a	method_16631
 CLASS	bd	net/minecraft/class_3218
 FIELD	bd	Lpc;	a	field_15775
@@ -9618,7 +9618,7 @@ METHOD	bd$a	()Z	a	method_14357
 METHOD	bd$a	(Ls$a;)V	a	method_14359
 METHOD	bd$a	(Ltd;Lcee;DDD)V	a	method_14358
 METHOD	bd$a	(Ls$a;)V	b	method_14360
-CLASS	bd$b	net/minecraft/class_3218$class_3696
+CLASS	bd$b	net/minecraft/class_3218$class_3697
 FIELD	bd$b	Lay;	a	field_18201
 FIELD	bd$b	Lay;	b	field_18202
 FIELD	bd$b	Lai;	c	field_18203
@@ -9662,7 +9662,7 @@ FIELD	bdd	[Lcew;	b	field_18227
 METHOD	bdd	(Laxz;Lel;Lblc;Laog;)Z	a	method_8698
 CLASS	bde	net/minecraft/class_1301
 FIELD	bde	[Lcew;	a	field_18228
-CLASS	bdf	net/minecraft/class_3697
+CLASS	bdf	net/minecraft/class_3698
 FIELD	bdf	Lbme;	a	field_18229
 FIELD	bdf	Lbli;	b	field_18230
 FIELD	bdf	Lbli;	c	field_18231
@@ -9734,18 +9734,18 @@ CLASS	bdo	net/minecraft/class_3207
 FIELD	bdo	Lblc;	a	field_18255
 METHOD	bdo	(Laxk;Lel;)Z	a	method_16653
 METHOD	bdo	(Lblc;)Z	x	method_16654
-CLASS	bdp	net/minecraft/class_3698
+CLASS	bdp	net/minecraft/class_3699
 FIELD	bdp	Lbmb;	a	field_18256
 FIELD	bdp	Lcew;	b	field_18257
-CLASS	bdq	net/minecraft/class_3699
+CLASS	bdq	net/minecraft/class_3700
 FIELD	bdq	Lbcs;	a	field_18258
 METHOD	bdq	(Laxk;Lel;)Z	a	method_16655
-CLASS	bdr	net/minecraft/class_3700
+CLASS	bdr	net/minecraft/class_3701
 FIELD	bdr	Lbcs;	a	field_18259
-CLASS	bds	net/minecraft/class_3701
+CLASS	bds	net/minecraft/class_3702
 FIELD	bds	Lcew;	a	field_18260
 FIELD	bds	Lbcs;	c	field_18261
-CLASS	bdt	net/minecraft/class_3702
+CLASS	bdt	net/minecraft/class_3703
 FIELD	bdt	Lbcs;	c	field_18262
 CLASS	bdu	net/minecraft/class_214
 CLASS	bdu$a	net/minecraft/class_214$class_2179
@@ -9764,7 +9764,7 @@ METHOD	bdv	()Laxx;	f	method_6469
 METHOD	bdv	()Laxx;	g	method_6468
 METHOD	bdv	(Lblc;)I	k	method_11598
 METHOD	bdv	(Lblc;)Z	w	method_11599
-CLASS	bdw	net/minecraft/class_3703
+CLASS	bdw	net/minecraft/class_3704
 FIELD	bdw	Lbmb;	a	field_18265
 FIELD	bdw	Lbmb;	b	field_18266
 FIELD	bdw	Lbmb;	c	field_18267
@@ -9777,7 +9777,7 @@ METHOD	bdw	(FFFFF)[Lcew;	a	method_16656
 METHOD	bdw	(Leq;)I	a	method_16657
 METHOD	bdw	(Ljava/util/Map$Entry;)Z	a	method_16658
 METHOD	bdw	(Lblc;)I	k	method_16659
-CLASS	bdw$1	net/minecraft/class_3703$1
+CLASS	bdw$1	net/minecraft/class_3704$1
 FIELD	bdw$1	[I	a	field_18273
 FIELD	bdw$1	[I	b	field_18274
 CLASS	bdx	net/minecraft/class_1448
@@ -9811,7 +9811,7 @@ METHOD	be$a	()Z	a	method_14372
 METHOD	be$a	(Lblc;Lel;Ltd;Late;)V	a	method_14373
 METHOD	be$a	(Ls$a;)V	a	method_14374
 METHOD	be$a	(Ls$a;)V	b	method_14375
-CLASS	be$b	net/minecraft/class_3222$class_3704
+CLASS	be$b	net/minecraft/class_3222$class_3705
 FIELD	be$b	Lbcs;	a	field_18284
 FIELD	be$b	Ljava/util/Map;	b	field_18285
 FIELD	be$b	Lay;	c	field_18286
@@ -9897,10 +9897,10 @@ FIELD	bem	Lbmb;	b	field_18313
 FIELD	bem	Lcew;	c	field_18314
 CLASS	ben	net/minecraft/class_1451
 METHOD	ben	(Laxk;)Lbji;	a	method_16671
-CLASS	beo	net/minecraft/class_3705
+CLASS	beo	net/minecraft/class_3706
 FIELD	beo	Lbmh;	C	field_18315
 METHOD	beo	(Lblc;)Leq;	k	method_16672
-CLASS	beo$1	net/minecraft/class_3705$1
+CLASS	beo$1	net/minecraft/class_3706$1
 FIELD	beo$1	[I	a	field_18316
 CLASS	bep	net/minecraft/class_1756
 FIELD	bep	Z	b	field_7453
@@ -9972,7 +9972,7 @@ CLASS	bex	net/minecraft/class_138
 FIELD	bex	Lbme;	a	field_9469
 FIELD	bex	Lbmb;	b	field_18348
 CLASS	bey	net/minecraft/class_140
-CLASS	bez	net/minecraft/class_3706
+CLASS	bez	net/minecraft/class_3707
 CLASS	bf	net/minecraft/class_3226
 FIELD	bf	Lpc;	a	field_15802
 FIELD	bf	Ljava/util/Map;	b	field_15803
@@ -9986,7 +9986,7 @@ METHOD	bf$a	()Z	a	method_14382
 METHOD	bf$a	(Ls$a;)V	a	method_14384
 METHOD	bf$a	(Ltf;Laer;Laea;FFZ)V	a	method_14383
 METHOD	bf$a	(Ls$a;)V	b	method_14385
-CLASS	bf$b	net/minecraft/class_3226$class_3707
+CLASS	bf$b	net/minecraft/class_3226$class_3708
 FIELD	bf$b	Lag;	a	field_18349
 FIELD	bf$b	Lao;	b	field_18350
 METHOD	bf$b	(Lag$a;)Lbf$b;	a	method_16683
@@ -10045,11 +10045,11 @@ CLASS	bfn	net/minecraft/class_175
 FIELD	bfn	Lbmb;	a	field_18379
 METHOD	bfn	(Laxy;Lel;)V	a	method_8802
 METHOD	bfn	(Laxz;Lel;Lblc;Late;)V	a	method_8801
-CLASS	bfo	net/minecraft/class_3708
+CLASS	bfo	net/minecraft/class_3709
 FIELD	bfo	Lbmj;	a	field_18380
 FIELD	bfo	Lcew;	b	field_18381
 METHOD	bfo	(Laxz;)Lblc;	a	method_16689
-CLASS	bfp	net/minecraft/class_3709
+CLASS	bfp	net/minecraft/class_3710
 FIELD	bfp	Lbfo;	a	field_18382
 CLASS	bfq	net/minecraft/class_149
 FIELD	bfq	Lbme;	a	field_9500
@@ -10086,7 +10086,7 @@ CLASS	bft$1	net/minecraft/class_151$1
 FIELD	bft$1	[I	a	field_18400
 FIELD	bft$1	[I	b	field_9508
 FIELD	bft$1	[I	c	field_18401
-CLASS	bfu	net/minecraft/class_3710
+CLASS	bfu	net/minecraft/class_3711
 FIELD	bfu	Lbmj;	a	field_18402
 FIELD	bfu	Lbyu;	b	field_18403
 FIELD	bfu	Ljava/util/List;	c	field_18404
@@ -10094,7 +10094,7 @@ FIELD	bfu	Ljava/util/Map;	o	field_18405
 METHOD	bfu	(Laxy;Lel;Lblc;)Z	a	method_16697
 METHOD	bfu	(Laxz;Lel;)V	a	method_16698
 METHOD	bfu	(Lblc;)Lcew;	k	method_16699
-CLASS	bfv	net/minecraft/class_3711
+CLASS	bfv	net/minecraft/class_3712
 METHOD	bfv	(Laxk;Lel;Lblc;Lbyv;)Z	a	method_16700
 METHOD	bfv	(Laxz;Lel;Lblc;Lbyw;)Z	a	method_16701
 CLASS	bfw	net/minecraft/class_206
@@ -10126,7 +10126,7 @@ METHOD	bg$a	()Z	a	method_14391
 METHOD	bg$a	(Lavk;)V	a	method_14392
 METHOD	bg$a	(Ls$a;)V	a	method_14393
 METHOD	bg$a	(Ls$a;)V	b	method_14394
-CLASS	bg$b	net/minecraft/class_3229$class_3712
+CLASS	bg$b	net/minecraft/class_3229$class_3713
 FIELD	bg$b	Lpc;	a	field_18407
 METHOD	bg$b	(Lavk;)Z	a	method_16702
 CLASS	bga	net/minecraft/class_160
@@ -10179,7 +10179,7 @@ METHOD	bgg	(Laxy;Lel;Lblc;)V	a	method_13713
 METHOD	bgg	(Laxz;Lel;)V	a	method_16710
 CLASS	bgh	net/minecraft/class_168
 CLASS	bgi	net/minecraft/class_1762
-CLASS	bgj	net/minecraft/class_3713
+CLASS	bgj	net/minecraft/class_3714
 FIELD	bgj	Lbmb;	a	field_18419
 FIELD	bgj	Lbmb;	b	field_18420
 FIELD	bgj	Lbmb;	c	field_18421
@@ -10192,8 +10192,8 @@ FIELD	bgj	[Leq;	t	field_18427
 METHOD	bgj	(F)[Lcew;	a	method_16711
 METHOD	bgj	(Ljava/util/EnumMap;)V	a	method_16712
 METHOD	bgj	(Lblc;)I	k	method_16713
-CLASS	bgk	net/minecraft/class_3714
-CLASS	bgl	net/minecraft/class_3715
+CLASS	bgk	net/minecraft/class_3715
+CLASS	bgl	net/minecraft/class_3716
 CLASS	bgm	net/minecraft/class_1304
 FIELD	bgm	[Lcew;	a	field_18428
 CLASS	bgn	net/minecraft/class_1453
@@ -10224,7 +10224,7 @@ CLASS	bgr$1	net/minecraft/class_173$1
 FIELD	bgr$1	[I	a	field_12728
 FIELD	bgr$1	[I	b	field_12729
 FIELD	bgr$1	[I	c	field_12730
-CLASS	bgs	net/minecraft/class_3716
+CLASS	bgs	net/minecraft/class_3717
 FIELD	bgs	Laxy;	a	field_18436
 FIELD	bgs	Lel;	b	field_18437
 FIELD	bgs	Lbco;	c	field_18438
@@ -10244,7 +10244,7 @@ METHOD	bgs	(Lbgs;)V	c	method_16723
 METHOD	bgs	(Lel;)Z	c	method_16724
 METHOD	bgs	()V	d	method_16725
 METHOD	bgs	(Lel;)Z	d	method_16726
-CLASS	bgs$1	net/minecraft/class_3716$1
+CLASS	bgs$1	net/minecraft/class_3717$1
 FIELD	bgs$1	[I	a	field_9251
 CLASS	bgt	net/minecraft/class_178
 FIELD	bgt	Lbmb;	a	field_18442
@@ -10287,7 +10287,7 @@ FIELD	bgw$a	Lel;	a	field_18453
 FIELD	bgw$a	J	b	field_18454
 METHOD	bgw$a	(Lbgw$a;)J	a	method_16730
 METHOD	bgw$a	(Lbgw$a;)Lel;	b	method_16731
-CLASS	bgx	net/minecraft/class_3717
+CLASS	bgx	net/minecraft/class_3718
 FIELD	bgx	Lbme;	b	field_18455
 FIELD	bgx	Lbmb;	c	field_18456
 CLASS	bgy	net/minecraft/class_2733
@@ -10313,7 +10313,7 @@ METHOD	bh$a	()Z	a	method_14400
 METHOD	bh$a	(Ls$a;)V	a	method_14402
 METHOD	bh$a	(Ltf;Laer;)V	a	method_14401
 METHOD	bh$a	(Ls$a;)V	b	method_14403
-CLASS	bh$b	net/minecraft/class_3232$class_3718
+CLASS	bh$b	net/minecraft/class_3232$class_3719
 FIELD	bh$b	Lao;	a	field_18459
 METHOD	bh$b	(Lao$a;)Lbh$b;	a	method_16732
 METHOD	bh$b	(Ltf;Laer;)Z	a	method_16733
@@ -10343,7 +10343,7 @@ FIELD	bhd	Lcew;	b	field_18463
 FIELD	bhd	Lbkl;	c	field_18464
 METHOD	bhd	(Laxz;Lel;Lblc;Ljava/util/Random;)V	a	method_16734
 CLASS	bhe	net/minecraft/class_2212
-CLASS	bhf	net/minecraft/class_3719
+CLASS	bhf	net/minecraft/class_3720
 FIELD	bhf	Lbmj;	a	field_18465
 FIELD	bhf	Lbmb;	b	field_18466
 FIELD	bhf	Lcew;	c	field_18467
@@ -10351,9 +10351,9 @@ FIELD	bhf	Lcew;	o	field_18468
 FIELD	bhf	Lcew;	p	field_18469
 FIELD	bhf	Lcew;	q	field_18470
 METHOD	bhf	(Lblc;)Z	k	method_16735
-CLASS	bhg	net/minecraft/class_3720
+CLASS	bhg	net/minecraft/class_3721
 FIELD	bhg	Lcew;	a	field_18471
-CLASS	bhh	net/minecraft/class_3721
+CLASS	bhh	net/minecraft/class_3722
 FIELD	bhh	Lbmh;	b	field_18472
 FIELD	bhh	Lbcs;	c	field_18473
 CLASS	bhi	net/minecraft/class_3066
@@ -10372,8 +10372,8 @@ FIELD	bhj	Lcew;	b	field_18476
 CLASS	bhk	net/minecraft/class_1305
 FIELD	bhk	Lbmj;	a	field_18477
 FIELD	bhk	Lcew;	b	field_18478
-CLASS	bhk$a	net/minecraft/class_1305$class_3722
-CLASS	bhk$b	net/minecraft/class_1305$class_3723
+CLASS	bhk$a	net/minecraft/class_1305$class_3723
+CLASS	bhk$b	net/minecraft/class_1305$class_3724
 FIELD	bhk$b	Lbhk$b;	a	field_18479
 FIELD	bhk$b	Lbhk$b;	b	field_18480
 FIELD	bhk$b	Lbhk$b;	c	field_18481
@@ -10393,12 +10393,12 @@ FIELD	bhl$1	[I	a	field_18490
 FIELD	bhl$1	[I	b	field_18491
 CLASS	bhm	net/minecraft/class_2213
 CLASS	bhn	net/minecraft/class_202
-CLASS	bho	net/minecraft/class_3724
+CLASS	bho	net/minecraft/class_3725
 FIELD	bho	Lbmj;	a	field_18492
 FIELD	bho	[Lcew;	b	field_18493
-CLASS	bho$1	net/minecraft/class_3724$1
+CLASS	bho$1	net/minecraft/class_3725$1
 FIELD	bho$1	[I	a	field_18494
-CLASS	bhp	net/minecraft/class_3725
+CLASS	bhp	net/minecraft/class_3726
 FIELD	bhp	Lbmb;	a	field_18495
 CLASS	bhq	net/minecraft/class_145
 FIELD	bhq	Lcew;	a	field_18496
@@ -10435,7 +10435,7 @@ CLASS	bhs	net/minecraft/class_159
 CLASS	bht	net/minecraft/class_187
 METHOD	bht	(Laxy;Lel;)V	a	method_16736
 METHOD	bht	(Laxy;Lel;)Z	b	method_8905
-CLASS	bhu	net/minecraft/class_3726
+CLASS	bhu	net/minecraft/class_3727
 METHOD	bhu	(Layc;Lel;)Z	a	method_16737
 METHOD	bhu	(Layc;Lel;)Z	b	method_16738
 CLASS	bhv	net/minecraft/class_1764
@@ -10496,11 +10496,11 @@ METHOD	bi$a	()Z	a	method_14408
 METHOD	bi$a	(Ls$a;)V	a	method_14410
 METHOD	bi$a	(Ltf;Lajq;)V	a	method_14409
 METHOD	bi$a	(Ls$a;)V	b	method_14411
-CLASS	bi$b	net/minecraft/class_3235$class_3727
+CLASS	bi$b	net/minecraft/class_3235$class_3728
 FIELD	bi$b	Lao;	a	field_18521
 METHOD	bi$b	(Ltf;Lajq;)Z	a	method_16747
 METHOD	bi$b	()Lbi$b;	c	method_16748
-CLASS	bia	net/minecraft/class_3728
+CLASS	bia	net/minecraft/class_3729
 METHOD	bia	()Lbhz;	d	method_16749
 METHOD	bia	()Lbcf;	e	method_16750
 CLASS	bib	net/minecraft/class_192
@@ -10515,10 +10515,10 @@ FIELD	bie	Lcew;	a	field_18523
 CLASS	bif	net/minecraft/class_180
 FIELD	bif	Lbmj;	a	field_18524
 FIELD	bif	Lcew;	b	field_18525
-CLASS	big	net/minecraft/class_3729
+CLASS	big	net/minecraft/class_3730
 CLASS	bih	net/minecraft/class_193
 FIELD	bih	Lcew;	a	field_18526
-CLASS	bii	net/minecraft/class_3730
+CLASS	bii	net/minecraft/class_3731
 FIELD	bii	Lbmh;	c	field_18527
 FIELD	bii	Lcew;	o	field_18528
 CLASS	bij	net/minecraft/class_201
@@ -10542,7 +10542,7 @@ METHOD	bil	(Laog;Laxy;Lel;Z)V	a	method_11640
 CLASS	bil$1	net/minecraft/class_205$1
 FIELD	bil$1	[I	a	field_9753
 FIELD	bil$1	[I	b	field_18541
-CLASS	bim	net/minecraft/class_3731
+CLASS	bim	net/minecraft/class_3732
 CLASS	bin	net/minecraft/class_208
 FIELD	bin	Lbmb;	a	field_18542
 FIELD	bin	Lbmb;	b	field_18543
@@ -10574,7 +10574,7 @@ METHOD	bio	(Laxy;Lel;Leq;)V	a	method_8945
 METHOD	bio	(Laxy;Lel;ZZZZ)V	a	method_11641
 CLASS	bio$1	net/minecraft/class_207$1
 FIELD	bio$1	[I	a	field_9770
-CLASS	bip	net/minecraft/class_3732
+CLASS	bip	net/minecraft/class_3733
 FIELD	bip	Lbmj;	a	field_18559
 FIELD	bip	Lbmj;	b	field_18560
 FIELD	bip	Lcew;	c	field_18561
@@ -10610,7 +10610,7 @@ METHOD	biq	(Lblc;)Z	x	method_16767
 CLASS	biq$1	net/minecraft/class_209$1
 FIELD	biq$1	[I	a	field_12828
 FIELD	biq$1	[I	b	field_12829
-CLASS	bir	net/minecraft/class_3733
+CLASS	bir	net/minecraft/class_3734
 FIELD	bir	Lbme;	a	field_18574
 FIELD	bir	Ljava/util/Map;	b	field_18575
 CLASS	bis	net/minecraft/class_1307
@@ -10622,10 +10622,10 @@ METHOD	bis	(Lbcs;)Z	f	method_14353
 CLASS	bit	net/minecraft/class_2223
 FIELD	bit	Lbme;	c	field_9791
 FIELD	bit	Ljava/util/Map;	o	field_18579
-CLASS	biu	net/minecraft/class_3734
+CLASS	biu	net/minecraft/class_3735
 FIELD	biu	Lbme;	a	field_18580
 FIELD	biu	Ljava/util/Map;	b	field_18581
-CLASS	biv	net/minecraft/class_3735
+CLASS	biv	net/minecraft/class_3736
 FIELD	biv	Lbme;	a	field_18582
 FIELD	biv	Ljava/util/Map;	b	field_18583
 CLASS	biw	net/minecraft/class_210
@@ -10634,7 +10634,7 @@ CLASS	bix	net/minecraft/class_211
 CLASS	biy	net/minecraft/class_1457
 FIELD	biy	Lbmj;	o	field_18585
 FIELD	biy	I	p	field_5640
-CLASS	biz	net/minecraft/class_3736
+CLASS	biz	net/minecraft/class_3737
 CLASS	bj	net/minecraft/class_3238
 FIELD	bj	Lpc;	a	field_15823
 FIELD	bj	Ljava/util/Map;	b	field_15824
@@ -10648,14 +10648,14 @@ METHOD	bj$a	(Ls$a;)V	a	method_14416
 METHOD	bj$a	()V	b	method_14417
 METHOD	bj$a	(Ls$a;)V	b	method_14418
 CLASS	bj$b	net/minecraft/class_3238$class_3240
-CLASS	bja	net/minecraft/class_3737
+CLASS	bja	net/minecraft/class_3738
 FIELD	bja	Lbli;	c	field_18586
 FIELD	bja	Lbli;	o	field_18587
 METHOD	bja	(Laxy;Lel;Lbkd;)V	a	method_16769
 METHOD	bja	(Laxy;Lel;Late;)Z	b	method_16770
 METHOD	bja	()Lbli;	d	method_16771
 METHOD	bja	()Lbli;	e	method_16772
-CLASS	bjb	net/minecraft/class_3738
+CLASS	bjb	net/minecraft/class_3739
 CLASS	bjc	net/minecraft/class_1458
 CLASS	bjd	net/minecraft/class_1596
 FIELD	bjd	Lcew;	a	field_18588
@@ -10798,7 +10798,7 @@ METHOD	bji	()Lblc;	w	method_16783
 METHOD	bji	()Z	x	method_552
 METHOD	bji	()V	y	method_547
 METHOD	bji	()V	z	method_553
-CLASS	bjj	net/minecraft/class_3739
+CLASS	bjj	net/minecraft/class_3740
 FIELD	bjj	Ljava/util/function/Supplier;	A	field_18595
 FIELD	bjj	Lcom/mojang/datafixers/types/Type;	B	field_18596
 FIELD	bjj	Lbjj;	a	field_18597
@@ -10832,7 +10832,7 @@ METHOD	bjj	(Lbjj;)Lpc;	a	method_16785
 METHOD	bjj	(Ljava/lang/String;)Lbji;	a	method_16786
 METHOD	bjj	(Ljava/lang/String;Lbjj$a;)Lbjj;	a	method_16787
 METHOD	bjj	()Lbji;	b	method_16788
-CLASS	bjj$a	net/minecraft/class_3739$class_3740
+CLASS	bjj$a	net/minecraft/class_3740$class_3741
 FIELD	bjj$a	Ljava/util/function/Supplier;	a	field_18623
 METHOD	bjj$a	(Lcom/mojang/datafixers/types/Type;)Lbjj;	a	method_16789
 METHOD	bjj$a	(Ljava/util/function/Supplier;)Lbjj$a;	a	method_16790
@@ -10890,7 +10890,7 @@ CLASS	bjn	net/minecraft/class_1459
 FIELD	bjn	I	a	field_5653
 METHOD	bjn	(I)V	a	method_4811
 METHOD	bjn	()I	c	method_4810
-CLASS	bjo	net/minecraft/class_3741
+CLASS	bjo	net/minecraft/class_3742
 FIELD	bjo	I	a	field_18625
 FIELD	bjo	[Lbcs;	e	field_18626
 FIELD	bjo	F	f	field_18627
@@ -11006,11 +11006,11 @@ METHOD	bjw	(I)V	d	method_4831
 METHOD	bjw	()Z	p	method_6524
 METHOD	bjw	()Z	r	method_6525
 METHOD	bjw	()Z	s	method_4835
-CLASS	bjx	net/minecraft/class_3742
+CLASS	bjx	net/minecraft/class_3743
 FIELD	bjx	Late;	a	field_18640
 METHOD	bjx	(Late;)V	a	method_16828
 METHOD	bjx	()Late;	c	method_16829
-CLASS	bjy	net/minecraft/class_3743
+CLASS	bjy	net/minecraft/class_3744
 METHOD	bjy	(F)F	a	method_16830
 CLASS	bjz	net/minecraft/class_2228
 FIELD	bjz	Ladp;	a	field_9855
@@ -11027,7 +11027,7 @@ METHOD	bk$a	()Z	a	method_14422
 METHOD	bk$a	(Ls$a;)V	a	method_14424
 METHOD	bk$a	(Ltf;Laob;Late;)V	a	method_14423
 METHOD	bk$a	(Ls$a;)V	b	method_14425
-CLASS	bk$b	net/minecraft/class_3241$class_3744
+CLASS	bk$b	net/minecraft/class_3241$class_3745
 FIELD	bk$b	Lao;	a	field_18641
 FIELD	bk$b	Lav;	b	field_18642
 METHOD	bk$b	(Ltf;Laob;Late;)Z	a	method_16831
@@ -11176,7 +11176,7 @@ METHOD	bkf	()Z	r	method_11682
 METHOD	bkf	()V	s	method_13332
 CLASS	bkf$1	net/minecraft/class_2738$1
 FIELD	bkf$1	[I	a	field_18648
-CLASS	bkf$a	net/minecraft/class_2738$class_3745
+CLASS	bkf$a	net/minecraft/class_2738$class_3746
 FIELD	bkf$a	Lbkf$a;	a	field_18649
 FIELD	bkf$a	Lbkf$a;	b	field_18650
 FIELD	bkf$a	Lbkf$a;	c	field_18651
@@ -11206,20 +11206,20 @@ METHOD	bkg	()Lel;	i	method_11698
 METHOD	bkg	()V	j	method_11699
 CLASS	bkh	net/minecraft/class_225
 METHOD	bkh	(Leq;)Z	a	method_11689
-CLASS	bki	net/minecraft/class_3746
-CLASS	bkk	net/minecraft/class_3747
+CLASS	bki	net/minecraft/class_3747
+CLASS	bkk	net/minecraft/class_3748
 METHOD	bkk	(Laxz;Lel;Lblc;Ljava/util/Random;II)Z	a	method_16846
 METHOD	bkk	(Lblc;Laxk;Lel;II)Z	a	method_16847
 METHOD	bkk	(Ljava/util/Random;)Lbpa;	a	method_16848
-CLASS	bkl	net/minecraft/class_3748
+CLASS	bkl	net/minecraft/class_3749
 METHOD	bkl	(Laxz;Lel;Lblc;Ljava/util/Random;)Z	a	method_16849
 METHOD	bkl	(Ljava/util/Random;)Lbpa;	b	method_16850
-CLASS	bkm	net/minecraft/class_3749
-CLASS	bkn	net/minecraft/class_3750
-CLASS	bko	net/minecraft/class_3751
-CLASS	bkp	net/minecraft/class_3752
-CLASS	bkq	net/minecraft/class_3753
-CLASS	bkr	net/minecraft/class_3754
+CLASS	bkm	net/minecraft/class_3750
+CLASS	bkn	net/minecraft/class_3751
+CLASS	bko	net/minecraft/class_3752
+CLASS	bkp	net/minecraft/class_3753
+CLASS	bkq	net/minecraft/class_3754
+CLASS	bkr	net/minecraft/class_3755
 CLASS	bku	net/minecraft/class_229
 FIELD	bku	Lbme;	a	field_9875
 FIELD	bku	Lbmh;	b	field_9876
@@ -11335,7 +11335,7 @@ METHOD	bl$a	(Ls$a;)V	b	method_14433
 CLASS	bl$b	net/minecraft/class_3244$class_3246
 FIELD	bl$b	Lba$c;	a	field_15837
 METHOD	bl$b	(D)Z	a	method_14434
-CLASS	bla	net/minecraft/class_3755
+CLASS	bla	net/minecraft/class_3756
 FIELD	bla	Ljava/util/function/Function;	b	field_18684
 FIELD	bla	Lcom/google/common/collect/ImmutableMap;	c	field_18685
 FIELD	bla	I	d	field_18686
@@ -11347,7 +11347,7 @@ METHOD	bla	(Lbmm;Ljava/lang/Comparable;)Ljava/util/Map;	b	method_16858
 METHOD	bla	(Ljava/lang/Object;)Z	equals	equals
 METHOD	bla	()I	hashCode	hashCode
 METHOD	bla	()Ljava/lang/String;	toString	toString
-CLASS	bla$1	net/minecraft/class_3755$1
+CLASS	bla$1	net/minecraft/class_3756$1
 METHOD	bla$1	(Lbmm;Ljava/lang/Comparable;)Ljava/lang/String;	a	method_11705
 METHOD	bla$1	(Ljava/util/Map$Entry;)Ljava/lang/String;	a	method_9022
 METHOD	bla$1	(Ljava/lang/Object;)Ljava/lang/Object;	apply	apply
@@ -11430,7 +11430,7 @@ METHOD	blc	()Z	t	method_16916
 METHOD	blc	()Lit/unimi/dsi/fastutil/objects/Object2ByteMap;	u	method_16917
 METHOD	blc	()Lit/unimi/dsi/fastutil/objects/Object2ByteMap;	v	method_16918
 METHOD	blc	()Lit/unimi/dsi/fastutil/objects/Object2ByteMap;	w	method_16919
-CLASS	bld	net/minecraft/class_3756
+CLASS	bld	net/minecraft/class_3757
 CLASS	ble	net/minecraft/class_2233
 FIELD	ble	Ljava/util/regex/Pattern;	a	field_12899
 FIELD	ble	Ljava/lang/Object;	b	field_18692
@@ -11446,15 +11446,15 @@ METHOD	ble	()Ljava/lang/Object;	c	method_16924
 METHOD	ble	()Ljava/util/Collection;	d	method_11742
 METHOD	ble	()Ljava/util/regex/Pattern;	e	method_16925
 METHOD	ble	()Ljava/lang/String;	toString	toString
-CLASS	ble$a	net/minecraft/class_2233$class_3757
+CLASS	ble$a	net/minecraft/class_2233$class_3758
 FIELD	ble$a	Ljava/lang/Object;	a	field_18693
 FIELD	ble$a	Ljava/util/Map;	b	field_18694
 METHOD	ble$a	(Lble$b;)Lble;	a	method_16926
 METHOD	ble$a	(Lbmm;)V	a	method_16927
 METHOD	ble$a	([Lbmm;)Lble$a;	a	method_16928
-CLASS	ble$b	net/minecraft/class_2233$class_3758
+CLASS	ble$b	net/minecraft/class_2233$class_3759
 METHOD	ble$b	(Ljava/lang/Object;Lcom/google/common/collect/ImmutableMap;)Lbla;	create	create
-CLASS	blf	net/minecraft/class_3759
+CLASS	blf	net/minecraft/class_3760
 METHOD	blf	()Ljava/util/Collection;	a	method_16929
 METHOD	blf	(Lbmm;)Ljava/lang/Object;	a	method_16930
 METHOD	blf	(Lbmm;Ljava/lang/Comparable;)Ljava/lang/Object;	a	method_16931
@@ -11518,11 +11518,11 @@ METHOD	blj	([Ljava/lang/String;)Lblj;	a	method_9058
 METHOD	blj	()Lbli;	b	method_9059
 METHOD	blj	()[[[Ljava/util/function/Predicate;	c	method_16941
 METHOD	blj	()V	d	method_9061
-CLASS	bll	net/minecraft/class_3760
+CLASS	bll	net/minecraft/class_3761
 FIELD	bll	Lbcs;	a	field_18698
 METHOD	bll	(Lbcs;)Lbll;	a	method_16942
 METHOD	bll	(Lblc;Laxk;Lel;)Z	a	method_16943
-CLASS	blm	net/minecraft/class_3761
+CLASS	blm	net/minecraft/class_3762
 METHOD	blm	(Ljava/lang/Object;Laxk;Lel;)Z	test	test
 CLASS	bln	net/minecraft/class_3012
 FIELD	bln	Lbln;	a	field_18699
@@ -11546,33 +11546,33 @@ METHOD	blp	(Lblc;Lbmm;Ljava/util/function/Predicate;)Z	a	method_16945
 METHOD	blp	(Lbmm;Ljava/util/function/Predicate;)Lblp;	a	method_16946
 METHOD	blp	(Lblc;)Z	b	method_16947
 METHOD	blp	(Ljava/lang/Object;)Z	test	test
-CLASS	blq	net/minecraft/class_3762
+CLASS	blq	net/minecraft/class_3763
 METHOD	blq	(Lblm;)Lblm;	a	method_16948
 METHOD	blq	([Ljava/lang/Object;)Ljava/util/List;	a	method_16949
 METHOD	blq	([Lblm;)Lblm;	b	method_16950
 METHOD	blq	(Ljava/lang/Iterable;)Ljava/util/List;	c	method_16951
-CLASS	blq$1	net/minecraft/class_3762$1
-CLASS	blq$b	net/minecraft/class_3762$class_3763
+CLASS	blq$1	net/minecraft/class_3763$1
+CLASS	blq$b	net/minecraft/class_3763$class_3764
 FIELD	blq$b	Lblm;	a	field_18701
-CLASS	blq$c	net/minecraft/class_3762$class_3764
+CLASS	blq$c	net/minecraft/class_3763$class_3765
 FIELD	blq$c	Ljava/util/List;	a	field_18702
-CLASS	blr	net/minecraft/class_3765
+CLASS	blr	net/minecraft/class_3766
 FIELD	blr	Lblr;	a	field_18703
 METHOD	blr	()Lblr;	a	method_16952
 METHOD	blr	(Lblc;Laxk;Lel;)Z	a	method_16953
-CLASS	bls	net/minecraft/class_3766
+CLASS	bls	net/minecraft/class_3767
 FIELD	bls	Lbls;	a	field_18704
 METHOD	bls	()Lbls;	a	method_16954
 METHOD	bls	(Lblc;Laxk;Lel;)Z	a	method_16955
-CLASS	blt	net/minecraft/class_3767
+CLASS	blt	net/minecraft/class_3768
 FIELD	blt	Lblt;	a	field_18705
 METHOD	blt	()Lblt;	a	method_16956
 METHOD	blt	(Lblc;Laxk;Lel;)Z	a	method_16957
-CLASS	blu	net/minecraft/class_3768
+CLASS	blu	net/minecraft/class_3769
 FIELD	blu	Lblu;	a	field_18706
 METHOD	blu	()Lblu;	a	method_16958
 METHOD	blu	(Lblc;Laxk;Lel;)Z	a	method_16959
-CLASS	blv	net/minecraft/class_3769
+CLASS	blv	net/minecraft/class_3770
 FIELD	blv	Lwz;	a	field_18707
 METHOD	blv	(Lblc;Laxk;Lel;)Z	a	method_16960
 METHOD	blv	(Lwz;)Lblv;	a	method_16961
@@ -11584,7 +11584,7 @@ METHOD	blx	()I	c	method_16962
 METHOD	blx	(Ljava/lang/Object;)Z	equals	equals
 METHOD	blx	()I	hashCode	hashCode
 METHOD	blx	()Ljava/lang/String;	toString	toString
-CLASS	bly	net/minecraft/class_3770
+CLASS	bly	net/minecraft/class_3771
 FIELD	bly	Lbly;	a	field_18709
 FIELD	bly	Lbly;	b	field_18710
 FIELD	bly	Lbly;	c	field_18711
@@ -11613,11 +11613,11 @@ METHOD	bm$a	()Z	a	method_14439
 METHOD	bm$a	(Late;)V	a	method_14440
 METHOD	bm$a	(Ls$a;)V	a	method_14441
 METHOD	bm$a	(Ls$a;)V	b	method_14442
-CLASS	bm$b	net/minecraft/class_3247$class_3771
+CLASS	bm$b	net/minecraft/class_3247$class_3772
 FIELD	bm$b	Lav;	a	field_18714
 METHOD	bm$b	(Late;)Z	a	method_16963
 METHOD	bm$b	(Laxx;)Lbm$b;	a	method_16964
-CLASS	bma	net/minecraft/class_3772
+CLASS	bma	net/minecraft/class_3773
 FIELD	bma	Lbmh;	A	field_18715
 FIELD	bma	Lbmb;	B	field_18716
 FIELD	bma	Lbmb;	C	field_18717
@@ -11699,7 +11699,7 @@ CLASS	bmb	net/minecraft/class_2243
 FIELD	bmb	Lcom/google/common/collect/ImmutableSet;	a	field_9924
 METHOD	bmb	(Ljava/lang/Boolean;)Ljava/lang/String;	a	method_9067
 METHOD	bmb	(Ljava/lang/String;)Lbmb;	a	method_9068
-CLASS	bmc	net/minecraft/class_3773
+CLASS	bmc	net/minecraft/class_3774
 FIELD	bmc	Lbmc;	a	field_18790
 FIELD	bmc	Lbmc;	b	field_18791
 FIELD	bmc	Lbmc;	c	field_18792
@@ -11744,7 +11744,7 @@ METHOD	bmh	(Ljava/lang/String;Ljava/lang/Class;)Lbmh;	a	method_9073
 METHOD	bmh	(Ljava/lang/String;Ljava/lang/Class;Ljava/util/Collection;)Lbmh;	a	method_9075
 METHOD	bmh	(Ljava/lang/String;Ljava/lang/Class;Ljava/util/function/Predicate;)Lbmh;	a	method_16970
 METHOD	bmh	(Ljava/lang/String;Ljava/lang/Class;[Ljava/lang/Enum;)Lbmh;	a	method_9076
-CLASS	bmi	net/minecraft/class_3774
+CLASS	bmi	net/minecraft/class_3775
 FIELD	bmi	Lbmi;	a	field_18797
 FIELD	bmi	Lbmi;	b	field_18798
 FIELD	bmi	Ljava/lang/String;	c	field_18799
@@ -11756,7 +11756,7 @@ CLASS	bmj	net/minecraft/class_2246
 FIELD	bmj	Lcom/google/common/collect/ImmutableSet;	a	field_9927
 METHOD	bmj	(Ljava/lang/Integer;)Ljava/lang/String;	a	method_9077
 METHOD	bmj	(Ljava/lang/String;II)Lbmj;	a	method_9078
-CLASS	bmk	net/minecraft/class_3775
+CLASS	bmk	net/minecraft/class_3776
 FIELD	bmk	Lbmk;	a	field_18801
 FIELD	bmk	Lbmk;	b	field_18802
 FIELD	bmk	Lbmk;	c	field_18803
@@ -11816,7 +11816,7 @@ FIELD	bmo	[Lbmo;	e	field_9636
 METHOD	bmo	()Ljava/lang/String;	toString	toString
 METHOD	bmo	(Ljava/lang/String;)Lbmo;	valueOf	valueOf
 METHOD	bmo	()[Lbmo;	values	values
-CLASS	bmp	net/minecraft/class_3776
+CLASS	bmp	net/minecraft/class_3777
 FIELD	bmp	Lbmp;	a	field_18814
 FIELD	bmp	Lbmp;	b	field_18815
 FIELD	bmp	Lbmp;	c	field_18816
@@ -11836,7 +11836,7 @@ FIELD	bmq	[Lbmq;	g	field_9687
 METHOD	bmq	()Ljava/lang/String;	toString	toString
 METHOD	bmq	(Ljava/lang/String;)Lbmq;	valueOf	valueOf
 METHOD	bmq	()[Lbmq;	values	values
-CLASS	bmr	net/minecraft/class_3777
+CLASS	bmr	net/minecraft/class_3778
 FIELD	bmr	Lbmr;	a	field_18819
 FIELD	bmr	Lbmr;	b	field_18820
 FIELD	bmr	Lbmr;	c	field_18821
@@ -11906,7 +11906,7 @@ METHOD	bmv	()I	p	method_9120
 METHOD	bmv	()I	q	method_9121
 METHOD	bmv	()V	r	method_16975
 CLASS	bmv$1	net/minecraft/class_2250$1
-CLASS	bmv$a	net/minecraft/class_2250$class_3778
+CLASS	bmv$a	net/minecraft/class_2250$class_3779
 METHOD	bmv$a	()D	a	method_16976
 METHOD	bmv$a	()D	b	method_16977
 METHOD	bmv$a	()D	c	method_16978
@@ -11919,14 +11919,14 @@ METHOD	bmv$a	()Lbmu;	i	method_16984
 METHOD	bmv$a	()V	j	method_16985
 METHOD	bmv$a	()V	k	method_16986
 METHOD	bmv$a	()Lbmv$a;	l	method_16987
-CLASS	bmv$b	net/minecraft/class_2250$class_3779
+CLASS	bmv$b	net/minecraft/class_2250$class_3780
 FIELD	bmv$b	Lbmv;	a	field_18826
 FIELD	bmv$b	D	b	field_18827
 FIELD	bmv$b	D	c	field_18828
 FIELD	bmv$b	J	d	field_18829
 FIELD	bmv$b	J	e	field_18830
 FIELD	bmv$b	D	f	field_18831
-CLASS	bmv$c	net/minecraft/class_2250$class_3780
+CLASS	bmv$c	net/minecraft/class_2250$class_3781
 FIELD	bmv$c	Lbmv;	a	field_18832
 FIELD	bmv$c	D	b	field_18833
 FIELD	bmv$c	D	c	field_18834
@@ -11934,7 +11934,7 @@ FIELD	bmv$c	D	d	field_18835
 FIELD	bmv$c	D	e	field_18836
 FIELD	bmv$c	D	f	field_18837
 METHOD	bmv$c	()V	m	method_16988
-CLASS	bmx	net/minecraft/class_3781
+CLASS	bmx	net/minecraft/class_3782
 METHOD	bmx	()Lbnk;	a	method_16989
 METHOD	bmx	(J)V	a	method_9143
 METHOD	bmx	(Laer;)V	a	method_3887
@@ -11984,7 +11984,7 @@ METHOD	bmy	(Lti;)V	b	method_17023
 METHOD	bmy	()J	c	method_17024
 METHOD	bmy	()I	d	method_17025
 METHOD	bmy	()I	e	method_17026
-CLASS	bmz	net/minecraft/class_3782
+CLASS	bmz	net/minecraft/class_3783
 FIELD	bmz	Laxz;	a	field_18838
 FIELD	bmz	J	b	field_18839
 FIELD	bmz	Layw;	c	field_18840
@@ -11995,7 +11995,7 @@ METHOD	bmz	(Lbmx;Ljava/util/Random;)V	a	method_17028
 METHOD	bmz	(Lbmx;[Layu;Lboz;I)V	a	method_17029
 METHOD	bmz	(Lbtl;)Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;	c	method_17030
 METHOD	bmz	(Lbtl;)Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;	d	method_17031
-CLASS	bn	net/minecraft/class_3783
+CLASS	bn	net/minecraft/class_3784
 FIELD	bn	Lbn;	a	field_18843
 FIELD	bn	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_18844
 FIELD	bn	Ljava/lang/Float;	c	field_18845
@@ -12006,9 +12006,9 @@ METHOD	bn	(Ljava/lang/Float;Ljava/util/function/Function;)Ljava/lang/Float;	a	me
 METHOD	bn	()Ljava/lang/Float;	b	method_17035
 METHOD	bn	(Lcom/mojang/brigadier/StringReader;Z)Ljava/lang/Float;	b	method_17036
 METHOD	bn	(Lcom/mojang/brigadier/StringReader;Z)Z	c	method_17037
-CLASS	bna	net/minecraft/class_3784
+CLASS	bna	net/minecraft/class_3785
 METHOD	bna	(Laxy;Layw;Lbom;)Lbmy;	create	create
-CLASS	bnb	net/minecraft/class_3785
+CLASS	bnb	net/minecraft/class_3786
 FIELD	bnb	Lbnb;	a	field_18847
 FIELD	bnb	Lbnb;	b	field_18848
 FIELD	bnb	Lbnb;	c	field_18849
@@ -12030,7 +12030,7 @@ METHOD	bnc	(Ljava/util/function/BooleanSupplier;)Z	a	method_17045
 METHOD	bnc	()V	close	close
 METHOD	bnc	()Ljava/lang/String;	e	method_3872
 METHOD	bnc	()Lbmy;	f	method_17046
-CLASS	bnd	net/minecraft/class_3786
+CLASS	bnd	net/minecraft/class_3787
 FIELD	bnd	Lbnd;	a	field_18856
 FIELD	bnd	Lbnd;	b	field_18857
 FIELD	bnd	Lbnd;	c	field_18858
@@ -12060,8 +12060,8 @@ METHOD	bnd	()Lbnd;	e	method_17055
 METHOD	bnd	()Z	f	method_17056
 METHOD	bnd	(Ljava/lang/String;)Lbnd;	valueOf	valueOf
 METHOD	bnd	()[Lbnd;	values	values
-CLASS	bnd$1	net/minecraft/class_3786$1
-CLASS	bnd$a	net/minecraft/class_3786$class_3787
+CLASS	bnd$1	net/minecraft/class_3787$1
+CLASS	bnd$a	net/minecraft/class_3787$class_3788
 FIELD	bnd$a	Lbnd$a;	a	field_18873
 FIELD	bnd$a	Lbnd$a;	b	field_18874
 FIELD	bnd$a	[Lbnd$a;	c	field_18875
@@ -12092,7 +12092,7 @@ FIELD	bnh	Ljava/util/function/Function;	e	field_18881
 FIELD	bnh	I	f	field_12910
 METHOD	bnh	()I	b	method_17058
 METHOD	bnh	(Lhe;)V	b	method_17059
-CLASS	bni	net/minecraft/class_3788
+CLASS	bni	net/minecraft/class_3789
 FIELD	bni	Lbmx;	a	field_18882
 METHOD	bni	(Lbcs;)Z	a	method_17060
 METHOD	bni	(Lbyv;)Z	a	method_17061
@@ -12341,7 +12341,7 @@ METHOD	bnr	()[Lit/unimi/dsi/fastutil/shorts/ShortList;	u	method_17144
 METHOD	bnr	()Lbnt;	v	method_17145
 METHOD	bnr	()Ljava/util/Map;	w	method_17146
 METHOD	bnr	()Z	x	method_17147
-CLASS	bns	net/minecraft/class_3789
+CLASS	bns	net/minecraft/class_3790
 FIELD	bns	Ljava/util/function/Predicate;	a	field_18930
 FIELD	bns	Ljava/util/function/Function;	b	field_18931
 FIELD	bns	Ljava/util/function/Function;	c	field_18932
@@ -12350,7 +12350,7 @@ FIELD	bns	[Lit/unimi/dsi/fastutil/shorts/ShortList;	e	field_18934
 METHOD	bns	()Lhe;	a	method_17148
 METHOD	bns	(Layo;Ljava/util/function/Function;)V	a	method_17149
 METHOD	bns	(Lhe;)V	a	method_17150
-CLASS	bnt	net/minecraft/class_3790
+CLASS	bnt	net/minecraft/class_3791
 FIELD	bnt	Lbnt;	a	field_18935
 FIELD	bnt	Lorg/apache/logging/log4j/Logger;	b	field_18936
 FIELD	bnt	[Ler;	c	field_18937
@@ -12367,11 +12367,11 @@ METHOD	bnt	()Lgy;	b	method_17156
 METHOD	bnt	(Lbnj;)V	b	method_17157
 METHOD	bnt	()Ljava/util/Map;	c	method_17158
 METHOD	bnt	()Ljava/util/Set;	d	method_17159
-CLASS	bnt$1	net/minecraft/class_3790$1
-CLASS	bnt$a	net/minecraft/class_3790$class_3791
+CLASS	bnt$1	net/minecraft/class_3791$1
+CLASS	bnt$a	net/minecraft/class_3791$class_3792
 METHOD	bnt$a	(Laxz;)V	a	method_17160
 METHOD	bnt$a	(Lblc;Leq;Lblc;Laxz;Lel;Lel;)Lblc;	a	method_17161
-CLASS	bnt$b	net/minecraft/class_3790$class_3792
+CLASS	bnt$b	net/minecraft/class_3791$class_3793
 FIELD	bnt$b	Lbnt$b;	a	field_18942
 FIELD	bnt$b	Lbnt$b;	b	field_18943
 FIELD	bnt$b	Lbnt$b;	c	field_18944
@@ -12381,13 +12381,13 @@ FIELD	bnt$b	[Leq;	f	field_18947
 FIELD	bnt$b	[Lbnt$b;	g	field_18948
 METHOD	bnt$b	(Ljava/lang/String;)Lbnt$b;	valueOf	valueOf
 METHOD	bnt$b	()[Lbnt$b;	values	values
-CLASS	bnt$b$1	net/minecraft/class_3790$class_3792$1
-CLASS	bnt$b$2	net/minecraft/class_3790$class_3792$2
-CLASS	bnt$b$3	net/minecraft/class_3790$class_3792$3
-CLASS	bnt$b$4	net/minecraft/class_3790$class_3792$4
+CLASS	bnt$b$1	net/minecraft/class_3791$class_3793$1
+CLASS	bnt$b$2	net/minecraft/class_3791$class_3793$2
+CLASS	bnt$b$3	net/minecraft/class_3791$class_3793$3
+CLASS	bnt$b$4	net/minecraft/class_3791$class_3793$4
 FIELD	bnt$b$4	Ljava/lang/ThreadLocal;	g	field_18949
 METHOD	bnt$b$4	()Ljava/util/List;	a	method_17162
-CLASS	bnt$b$5	net/minecraft/class_3790$class_3792$5
+CLASS	bnt$b$5	net/minecraft/class_3791$class_3793$5
 CLASS	bnv	net/minecraft/class_1205
 FIELD	bnv	Lorg/apache/logging/log4j/Logger;	a	field_7509
 FIELD	bnv	Ljava/util/Map;	b	field_9957
@@ -12513,7 +12513,7 @@ METHOD	boc	()Lbmy;	n	method_17193
 METHOD	boc	()Z	o	method_3987
 METHOD	boc	()Z	p	method_3988
 METHOD	boc	()Lbod;	q	method_11789
-CLASS	bod	net/minecraft/class_3793
+CLASS	bod	net/minecraft/class_3794
 FIELD	bod	Lbod;	a	field_18954
 FIELD	bod	Lbod;	b	field_18955
 FIELD	bod	Lbod;	c	field_18956
@@ -12535,7 +12535,7 @@ METHOD	bod	()Ljava/lang/String;	toString	toString
 CLASS	boe	net/minecraft/class_1209
 CLASS	boe$1	net/minecraft/class_1209$1
 FIELD	boe$1	Lboe;	a	field_9959
-CLASS	bof	net/minecraft/class_3794
+CLASS	bof	net/minecraft/class_3795
 CLASS	bog	net/minecraft/class_2751
 FIELD	bog	Lbog;	a	field_12928
 FIELD	bog	Lbog;	b	field_12929
@@ -12596,14 +12596,14 @@ METHOD	boh	()V	l	method_11815
 METHOD	boh	()V	m	method_11816
 METHOD	boh	()Lald;	n	method_11817
 CLASS	boh$1	net/minecraft/class_2752$1
-CLASS	boh$a	net/minecraft/class_2752$class_3795
+CLASS	boh$a	net/minecraft/class_2752$class_3796
 FIELD	boh$a	Lboh$a;	a	field_18962
 FIELD	boh$a	Lboh$a;	b	field_18963
 FIELD	boh$a	Lboh$a;	c	field_18964
 FIELD	boh$a	[Lboh$a;	d	field_18965
 METHOD	boh$a	(Ljava/lang/String;)Lboh$a;	valueOf	valueOf
 METHOD	boh$a	()[Lboh$a;	values	values
-CLASS	boh$b	net/minecraft/class_2752$class_3796
+CLASS	boh$b	net/minecraft/class_2752$class_3797
 FIELD	boh$b	Lboh;	a	field_18966
 FIELD	boh$b	Lboh$a;	b	field_18967
 METHOD	boh$b	()Z	a	method_17210
@@ -12612,7 +12612,7 @@ CLASS	boi	net/minecraft/class_1211
 FIELD	boi	Lel;	g	field_18968
 FIELD	boi	Lboh;	h	field_12952
 METHOD	boi	()Lboh;	r	method_11818
-CLASS	bol	net/minecraft/class_3797
+CLASS	bol	net/minecraft/class_3798
 FIELD	bol	I	a	field_18969
 FIELD	bol	I	b	field_18970
 FIELD	bol	I	c	field_18971
@@ -12634,7 +12634,7 @@ FIELD	bol	Lblc;	r	field_18986
 FIELD	bol	Lblc;	s	field_18987
 METHOD	bol	(Lblc;)V	a	method_17212
 METHOD	bol	(Lblc;)V	b	method_17213
-CLASS	bom	net/minecraft/class_3798
+CLASS	bom	net/minecraft/class_3799
 METHOD	bom	()I	a	method_17214
 METHOD	bom	()I	b	method_17215
 METHOD	bom	()I	c	method_17216
@@ -12654,7 +12654,7 @@ METHOD	bom	()I	p	method_17229
 METHOD	bom	()I	q	method_17230
 METHOD	bom	()Lblc;	r	method_17231
 METHOD	bom	()Lblc;	s	method_17232
-CLASS	bon	net/minecraft/class_3799
+CLASS	bon	net/minecraft/class_3800
 CLASS	boo	net/minecraft/class_2256
 FIELD	boo	Lblc;	f	field_12956
 FIELD	boo	Lblc;	g	field_12957
@@ -12673,16 +12673,16 @@ FIELD	bop	Lbow;	i	field_18992
 METHOD	bop	(IILbmx;)V	a	method_17235
 METHOD	bop	()Lbud;	f	method_17236
 METHOD	bop	()Layu;	g	method_17237
-CLASS	bop$a	net/minecraft/class_1213$class_3800
+CLASS	bop$a	net/minecraft/class_1213$class_3801
 FIELD	bop$a	Lbop;	aZ	field_18993
-CLASS	boq	net/minecraft/class_3801
-CLASS	boq$a	net/minecraft/class_3801$class_3802
+CLASS	boq	net/minecraft/class_3802
+CLASS	boq$a	net/minecraft/class_3802$class_3803
 FIELD	boq$a	Lboq$a;	a	field_18994
 FIELD	boq$a	Lboq$a;	b	field_18995
 FIELD	boq$a	[Lboq$a;	c	field_18996
 METHOD	boq$a	(Ljava/lang/String;)Lboq$a;	valueOf	valueOf
 METHOD	boq$a	()[Lboq$a;	values	values
-CLASS	boq$b	net/minecraft/class_3801$class_3803
+CLASS	boq$b	net/minecraft/class_3802$class_3804
 FIELD	boq$b	Lboq$b;	a	field_18997
 FIELD	boq$b	Lboq$b;	b	field_18998
 FIELD	boq$b	Lboq$b;	c	field_18999
@@ -12694,7 +12694,7 @@ FIELD	boq$b	Lboq$b;	h	field_19004
 FIELD	boq$b	[Lboq$b;	i	field_19005
 METHOD	boq$b	(Ljava/lang/String;)Lboq$b;	valueOf	valueOf
 METHOD	boq$b	()[Lboq$b;	values	values
-CLASS	bor	net/minecraft/class_3804
+CLASS	bor	net/minecraft/class_3805
 FIELD	bor	Lxd;	a	field_19006
 FIELD	bor	Lblm;	b	field_19007
 FIELD	bor	Lbmx;	c	field_19008
@@ -12707,7 +12707,7 @@ METHOD	bor	(Lel$a;IILblm;I)I	a	method_17243
 METHOD	bor	([J)V	a	method_17244
 METHOD	bor	()[J	b	method_17245
 METHOD	bor	(II)I	b	method_17246
-CLASS	bor$a	net/minecraft/class_3804$class_3805
+CLASS	bor$a	net/minecraft/class_3805$class_3806
 FIELD	bor$a	Lbor$a;	a	field_19009
 FIELD	bor$a	Lbor$a;	b	field_19010
 FIELD	bor$a	Lbor$a;	c	field_19011
@@ -12727,14 +12727,14 @@ METHOD	bor$a	()Ljava/lang/String;	b	method_17250
 METHOD	bor$a	()Lbor$b;	c	method_17251
 METHOD	bor$a	(Ljava/lang/String;)Lbor$a;	valueOf	valueOf
 METHOD	bor$a	()[Lbor$a;	values	values
-CLASS	bor$b	net/minecraft/class_3804$class_3806
+CLASS	bor$b	net/minecraft/class_3805$class_3807
 FIELD	bor$b	Lbor$b;	a	field_19021
 FIELD	bor$b	Lbor$b;	b	field_19022
 FIELD	bor$b	[Lbor$b;	c	field_19023
 METHOD	bor$b	(Ljava/lang/String;)Lbor$b;	valueOf	valueOf
 METHOD	bor$b	()[Lbor$b;	values	values
-CLASS	bos	net/minecraft/class_3807
-CLASS	bot	net/minecraft/class_3808
+CLASS	bos	net/minecraft/class_3808
+CLASS	bot	net/minecraft/class_3809
 FIELD	bot	Lblc;	f	field_19024
 FIELD	bot	Lblc;	g	field_19025
 FIELD	bot	Lblc;	h	field_19026
@@ -12750,7 +12750,7 @@ FIELD	bot	Lblc;	q	field_19035
 METHOD	bot	(IIIIII)[D	a	method_17252
 METHOD	bot	(IILbmx;)V	a	method_17253
 METHOD	bot	()Lbos;	f	method_17254
-CLASS	bou	net/minecraft/class_3809
+CLASS	bou	net/minecraft/class_3810
 FIELD	bou	F	A	field_19036
 FIELD	bou	F	B	field_19037
 FIELD	bou	F	C	field_19038
@@ -12808,10 +12808,10 @@ FIELD	bov	Lblc;	r	field_19060
 METHOD	bov	(IILbmx;)V	a	method_17275
 METHOD	bov	([Layu;III[D)V	a	method_17276
 METHOD	bov	()Lbou;	f	method_17277
-CLASS	bow	net/minecraft/class_3810
+CLASS	bow	net/minecraft/class_3811
 FIELD	bow	I	a	field_19061
 METHOD	bow	(Laxy;ZZ)I	a	method_17278
-CLASS	box	net/minecraft/class_3811
+CLASS	box	net/minecraft/class_3812
 FIELD	box	Lel;	t	field_19062
 METHOD	box	(Lel;)Lbox;	a	method_17279
 METHOD	box	()Lel;	t	method_17280
@@ -12831,7 +12831,7 @@ METHOD	boy	(IIIIII)[D	a	method_17281
 METHOD	boy	(IILbmx;)V	a	method_17282
 METHOD	boy	()Lel;	f	method_17283
 METHOD	boy	()Lbox;	g	method_17284
-CLASS	boz	net/minecraft/class_3812
+CLASS	boz	net/minecraft/class_3813
 FIELD	boz	I	a	field_19067
 METHOD	boz	(I)V	a	method_17285
 METHOD	boz	(II)J	a	method_17286
@@ -12869,28 +12869,28 @@ CLASS	bpc	net/minecraft/class_1221
 FIELD	bpc	Lblc;	a	field_10140
 FIELD	bpc	Lblc;	b	field_10141
 FIELD	bpc	Z	c	field_7518
-CLASS	bpd	net/minecraft/class_3813
+CLASS	bpd	net/minecraft/class_3814
 FIELD	bpd	Lbcs;	a	field_19070
 FIELD	bpd	I	b	field_19071
 CLASS	bpe	net/minecraft/class_1770
 METHOD	bpe	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpd;)Z	a	method_17306
-CLASS	bpf	net/minecraft/class_3814
+CLASS	bpf	net/minecraft/class_3815
 METHOD	bpf	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17307
-CLASS	bpg	net/minecraft/class_3815
+CLASS	bpg	net/minecraft/class_3816
 METHOD	bpg	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17308
-CLASS	bph	net/minecraft/class_3816
+CLASS	bph	net/minecraft/class_3817
 FIELD	bph	F	a	field_19072
-CLASS	bpi	net/minecraft/class_3817
-CLASS	bpi$a	net/minecraft/class_3817$class_3818
-CLASS	bpj	net/minecraft/class_3819
+CLASS	bpi	net/minecraft/class_3818
+CLASS	bpi$a	net/minecraft/class_3818$class_3819
+CLASS	bpj	net/minecraft/class_3820
 FIELD	bpj	Lbcs;	a	field_19073
 CLASS	bpk	net/minecraft/class_2258
 METHOD	bpk	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpj;)Z	a	method_17309
 CLASS	bpl	net/minecraft/class_1223
 METHOD	bpl	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17310
-CLASS	bpm	net/minecraft/class_3820
+CLASS	bpm	net/minecraft/class_3821
 METHOD	bpm	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17311
-CLASS	bpn	net/minecraft/class_3821
+CLASS	bpn	net/minecraft/class_3822
 FIELD	bpn	Lbqo;	a	field_19074
 FIELD	bpn	Lbqp;	b	field_19075
 FIELD	bpn	Lbvg;	c	field_19076
@@ -12898,39 +12898,39 @@ FIELD	bpn	Lbpx;	d	field_19077
 METHOD	bpn	()Lbqo;	a	method_17312
 METHOD	bpn	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17313
 METHOD	bpn	()Ljava/lang/String;	toString	toString
-CLASS	bpo	net/minecraft/class_3822
-CLASS	bpp	net/minecraft/class_3823
+CLASS	bpo	net/minecraft/class_3823
+CLASS	bpp	net/minecraft/class_3824
 METHOD	bpp	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17314
 METHOD	bpp	(Laxz;Ljava/util/Random;Lel;Lblc;)Z	a	method_17315
 METHOD	bpp	(Laxz;Ljava/util/Random;Lel;Lblc;)Z	b	method_17316
-CLASS	bpq	net/minecraft/class_3824
-CLASS	bpr	net/minecraft/class_3825
-CLASS	bps	net/minecraft/class_3826
+CLASS	bpq	net/minecraft/class_3825
+CLASS	bpr	net/minecraft/class_3826
+CLASS	bps	net/minecraft/class_3827
 METHOD	bps	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuy;Lbqo;Lbqp;)Z	a	method_17317
-CLASS	bpt	net/minecraft/class_3827
+CLASS	bpt	net/minecraft/class_3828
 METHOD	bpt	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuy;Lbqo;Lbqp;)Z	a	method_17318
-CLASS	bpu	net/minecraft/class_3828
+CLASS	bpu	net/minecraft/class_3829
 FIELD	bpu	I	a	field_19078
 CLASS	bpv	net/minecraft/class_1225
 FIELD	bpv	Lbdy;	a	field_19079
 METHOD	bpv	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17319
-CLASS	bpw	net/minecraft/class_3829
+CLASS	bpw	net/minecraft/class_3830
 FIELD	bpw	F	a	field_19080
 FIELD	bpw	I	b	field_19081
 FIELD	bpw	I	c	field_19082
 FIELD	bpw	I	d	field_19083
-CLASS	bpx	net/minecraft/class_3830
+CLASS	bpx	net/minecraft/class_3831
 FIELD	bpx	Lbry;	e	field_19084
-CLASS	bpy	net/minecraft/class_3831
+CLASS	bpy	net/minecraft/class_3832
 FIELD	bpy	I	a	field_19085
 FIELD	bpy	I	b	field_19086
 FIELD	bpy	I	c	field_19087
 FIELD	bpy	I	d	field_19088
-CLASS	bpz	net/minecraft/class_3832
+CLASS	bpz	net/minecraft/class_3833
 FIELD	bpz	D	a	field_19089
 FIELD	bpz	I	b	field_19090
 FIELD	bpz	I	c	field_19091
-CLASS	bq	net/minecraft/class_3833
+CLASS	bq	net/minecraft/class_3834
 FIELD	bq	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	a	field_19092
 FIELD	bq	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	b	field_19093
 FIELD	bq	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	c	field_19094
@@ -12991,34 +12991,34 @@ METHOD	bq	()Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	reader
 METHOD	bq	()Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	readerInvalidEscape	readerInvalidEscape
 METHOD	bq	()Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	readerInvalidFloat	readerInvalidFloat
 METHOD	bq	()Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	readerInvalidInt	readerInvalidInt
-CLASS	bqa	net/minecraft/class_3834
-CLASS	bqb	net/minecraft/class_3835
-CLASS	bqc	net/minecraft/class_3836
-CLASS	bqc$a	net/minecraft/class_3836$class_3837
+CLASS	bqa	net/minecraft/class_3835
+CLASS	bqb	net/minecraft/class_3836
+CLASS	bqc	net/minecraft/class_3837
+CLASS	bqc$a	net/minecraft/class_3837$class_3838
 CLASS	bqd	net/minecraft/class_1226
 FIELD	bqd	Lblp;	a	field_10144
 FIELD	bqd	Lblc;	b	field_10145
 FIELD	bqd	Lblc;	c	field_10146
 FIELD	bqd	Lblc;	d	field_10147
 METHOD	bqd	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17334
-CLASS	bqe	net/minecraft/class_3838
+CLASS	bqe	net/minecraft/class_3839
 FIELD	bqe	Lbcs;	a	field_19115
 FIELD	bqe	I	b	field_19116
 FIELD	bqe	I	c	field_19117
 FIELD	bqe	Ljava/util/List;	d	field_19118
-CLASS	bqf	net/minecraft/class_3839
+CLASS	bqf	net/minecraft/class_3840
 METHOD	bqf	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbqe;)Z	a	method_17335
-CLASS	bqg	net/minecraft/class_3840
+CLASS	bqg	net/minecraft/class_3841
 FIELD	bqg	Lblc;	a	field_19119
 CLASS	bqh	net/minecraft/class_1771
 METHOD	bqh	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbqg;)Z	a	method_17336
-CLASS	bqi	net/minecraft/class_3841
-CLASS	bqj	net/minecraft/class_3842
+CLASS	bqi	net/minecraft/class_3842
+CLASS	bqj	net/minecraft/class_3843
 METHOD	bqj	(IILbmy;)I	a	method_17337
 METHOD	bqj	(IILbmy;)I	b	method_17338
-CLASS	bqj$a	net/minecraft/class_3842$class_2758
+CLASS	bqj$a	net/minecraft/class_3843$class_2758
 FIELD	bqj$a	Z	e	field_12994
-CLASS	bqk	net/minecraft/class_3843
+CLASS	bqk	net/minecraft/class_3844
 FIELD	bqk	Z	a	field_19120
 METHOD	bqk	()Z	a	method_17339
 CLASS	bql	net/minecraft/class_2753
@@ -13029,7 +13029,7 @@ CLASS	bqn	net/minecraft/class_2755
 FIELD	bqn	Lel;	a	field_12979
 FIELD	bqn	Z	b	field_12981
 METHOD	bqn	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17342
-CLASS	bqo	net/minecraft/class_3844
+CLASS	bqo	net/minecraft/class_3845
 FIELD	bqo	Lbpa;	A	field_19121
 FIELD	bqo	Lbpa;	B	field_19122
 FIELD	bqo	Lbpa;	C	field_19123
@@ -13117,16 +13117,16 @@ METHOD	bqo	(Laxz;Lel;Lblc;)V	a	method_17344
 METHOD	bqo	(Laxz;Ljava/lang/String;Lel;)Z	a	method_17345
 METHOD	bqo	(Ljava/util/HashMap;)V	a	method_17346
 METHOD	bqo	()Ljava/util/List;	d	method_17347
-CLASS	bqp	net/minecraft/class_3845
+CLASS	bqp	net/minecraft/class_3846
 FIELD	bqp	Lbrz;	e	field_19203
-CLASS	bqq	net/minecraft/class_3846
+CLASS	bqq	net/minecraft/class_3847
 FIELD	bqq	I	a	field_19204
-CLASS	bqr	net/minecraft/class_3847
+CLASS	bqr	net/minecraft/class_3848
 METHOD	bqr	(Ljava/util/Random;Lel;)Lblc;	a	method_17348
-CLASS	bqs	net/minecraft/class_3848
+CLASS	bqs	net/minecraft/class_3849
 METHOD	bqs	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17349
 METHOD	bqs	(Ljava/util/Random;Lel;)Lblc;	a	method_17350
-CLASS	bqt	net/minecraft/class_3849
+CLASS	bqt	net/minecraft/class_3850
 FIELD	bqt	[Lbcs;	a	field_19205
 CLASS	bqu	net/minecraft/class_3013
 FIELD	bqu	Lpc;	aH	field_14850
@@ -13153,12 +13153,12 @@ FIELD	bqv	Lblc;	a	field_10151
 FIELD	bqv	Lblc;	b	field_10152
 CLASS	bqw	net/minecraft/class_1231
 METHOD	bqw	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17352
-CLASS	bqx	net/minecraft/class_3850
+CLASS	bqx	net/minecraft/class_3851
 FIELD	bqx	Z	a	field_19206
 CLASS	bqy	net/minecraft/class_1233
 FIELD	bqy	Lblc;	a	field_19207
 METHOD	bqy	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbqx;)Z	a	method_17353
-CLASS	bqz	net/minecraft/class_3851
+CLASS	bqz	net/minecraft/class_3852
 METHOD	bqz	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17354
 CLASS	br	net/minecraft/class_3270
 FIELD	br	[Lbr$c;	a	field_15997
@@ -13182,16 +13182,16 @@ METHOD	br$c	(Lpp;Lbu;Ljava/util/ArrayDeque;I)V	a	method_14541
 CLASS	br$d	net/minecraft/class_3270$class_3274
 FIELD	br$d	Lbr$a;	a	field_16003
 METHOD	br$d	()Ljava/lang/String;	toString	toString
-CLASS	bra	net/minecraft/class_3852
+CLASS	bra	net/minecraft/class_3853
 METHOD	bra	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17359
 CLASS	brb	net/minecraft/class_1772
 FIELD	brb	Lbcs;	a	field_7527
 METHOD	brb	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbqq;)Z	a	method_17360
 CLASS	brc	net/minecraft/class_1773
 METHOD	brc	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17361
-CLASS	brd	net/minecraft/class_3853
+CLASS	brd	net/minecraft/class_3854
 FIELD	brd	Lblc;	a	field_19210
-CLASS	bre	net/minecraft/class_3854
+CLASS	bre	net/minecraft/class_3855
 METHOD	bre	(III)I	a	method_17362
 METHOD	bre	(IILel;IID)D	a	method_17363
 METHOD	bre	(IILel;ILjava/util/Random;)D	a	method_17364
@@ -13207,24 +13207,24 @@ METHOD	bre	(Ljava/util/Random;III)I	a	method_17373
 METHOD	bre	(Ljava/util/Random;Laxz;IILel;ZIDI)V	a	method_17374
 METHOD	bre	(III)I	b	method_17375
 METHOD	bre	(Ljava/util/Random;III)I	b	method_17376
-CLASS	brf	net/minecraft/class_3855
-CLASS	brg	net/minecraft/class_3856
-CLASS	brg$a	net/minecraft/class_3856$class_3857
-CLASS	brh	net/minecraft/class_3858
+CLASS	brf	net/minecraft/class_3856
+CLASS	brg	net/minecraft/class_3857
+CLASS	brg$a	net/minecraft/class_3857$class_3858
+CLASS	brh	net/minecraft/class_3859
 METHOD	brh	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17377
 METHOD	brh	(Ljava/util/Random;)Lblc;	a	method_17378
-CLASS	bri	net/minecraft/class_3859
-CLASS	brj	net/minecraft/class_3860
-CLASS	brj$a	net/minecraft/class_3860$class_3861
-CLASS	brk	net/minecraft/class_3862
-CLASS	brl	net/minecraft/class_3863
+CLASS	bri	net/minecraft/class_3860
+CLASS	brj	net/minecraft/class_3861
+CLASS	brj$a	net/minecraft/class_3861$class_3862
+CLASS	brk	net/minecraft/class_3863
+CLASS	brl	net/minecraft/class_3864
 METHOD	brl	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17379
-CLASS	brm	net/minecraft/class_3864
+CLASS	brm	net/minecraft/class_3865
 FIELD	brm	Lbcs;	a	field_19211
 CLASS	brn	net/minecraft/class_1235
 FIELD	brn	Lblc;	a	field_19212
 METHOD	brn	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrm;)Z	a	method_17380
-CLASS	bro	net/minecraft/class_3865
+CLASS	bro	net/minecraft/class_3866
 METHOD	bro	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17381
 CLASS	brp	net/minecraft/class_1774
 METHOD	brp	(Laxz;Ljava/util/Random;Lel;Lbmb;)V	a	method_9211
@@ -13251,13 +13251,13 @@ METHOD	brr	(Laxz;Lel;I)V	b	method_17385
 METHOD	brr	(Laxz;Lel;I)V	c	method_17386
 CLASS	brs	net/minecraft/class_1776
 METHOD	brs	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17387
-CLASS	brt	net/minecraft/class_3866
+CLASS	brt	net/minecraft/class_3867
 FIELD	brt	D	a	field_19215
 FIELD	brt	Lbru$b;	b	field_19216
-CLASS	bru	net/minecraft/class_3867
-CLASS	bru$a	net/minecraft/class_3867$class_1258
+CLASS	bru	net/minecraft/class_3868
+CLASS	bru$a	net/minecraft/class_1258
 FIELD	bru$a	Lbru$b;	e	field_19217
-CLASS	bru$b	net/minecraft/class_3867$class_3014
+CLASS	bru$b	net/minecraft/class_3868$class_3014
 FIELD	bru$b	Lbru$b;	a	field_14864
 FIELD	bru$b	Lbru$b;	b	field_14865
 FIELD	bru$b	[Lbru$b;	c	field_14866
@@ -13270,27 +13270,27 @@ FIELD	brv	[Laev;	b	field_19218
 FIELD	brv	Lblc;	c	field_19219
 METHOD	brv	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17388
 METHOD	brv	(Ljava/util/Random;)Laev;	a	method_17389
-CLASS	brw	net/minecraft/class_3868
-CLASS	brx	net/minecraft/class_3869
+CLASS	brw	net/minecraft/class_3869
+CLASS	brx	net/minecraft/class_3870
 FIELD	brx	Ljava/util/List;	b	field_19220
-CLASS	brx$a	net/minecraft/class_3869$class_1260
-CLASS	bry	net/minecraft/class_3870
-CLASS	brz	net/minecraft/class_3871
+CLASS	brx$a	net/minecraft/class_3870$class_1260
+CLASS	bry	net/minecraft/class_3871
+CLASS	brz	net/minecraft/class_3872
 CLASS	bs	net/minecraft/class_55
 FIELD	bs	Lij;	a	field_19221
 METHOD	bs	()Lij;	a	method_17390
-CLASS	bsa	net/minecraft/class_3872
-CLASS	bsb	net/minecraft/class_3873
+CLASS	bsa	net/minecraft/class_3873
+CLASS	bsb	net/minecraft/class_3874
 FIELD	bsb	Ljava/util/List;	b	field_19222
-CLASS	bsb$a	net/minecraft/class_3873$class_2260
+CLASS	bsb$a	net/minecraft/class_3874$class_2260
 FIELD	bsb$a	Ljava/util/Set;	e	field_10192
 FIELD	bsb$a	Z	f	field_10193
 METHOD	bsb$a	(Laxk;Ljava/util/Random;II)V	b	method_9241
-CLASS	bsc	net/minecraft/class_3874
+CLASS	bsc	net/minecraft/class_3875
 FIELD	bsc	Lbwt$b;	a	field_19223
 FIELD	bsc	F	b	field_19224
 FIELD	bsc	F	c	field_19225
-CLASS	bsd	net/minecraft/class_3875
+CLASS	bsd	net/minecraft/class_3876
 FIELD	bsd	Ljava/util/function/Predicate;	a	field_19226
 FIELD	bsd	Ljava/util/function/Predicate;	b	field_19227
 FIELD	bsd	I	c	field_19228
@@ -13302,45 +13302,45 @@ METHOD	bse	(Laxz;Ljava/util/Random;Lbsd;DDDDDDIIIII)Z	a	method_17393
 CLASS	bsf	net/minecraft/class_1240
 FIELD	bsf	Lblc;	a	field_10164
 FIELD	bsf	Lblc;	b	field_19230
-CLASS	bsg	net/minecraft/class_3876
-CLASS	bsh	net/minecraft/class_3877
+CLASS	bsg	net/minecraft/class_3877
+CLASS	bsh	net/minecraft/class_3878
 FIELD	bsh	F	a	field_19231
 CLASS	bsi	net/minecraft/class_1241
 METHOD	bsi	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17394
-CLASS	bsj	net/minecraft/class_3878
+CLASS	bsj	net/minecraft/class_3879
 FIELD	bsj	Lbqo;	a	field_19232
 FIELD	bsj	Lbqp;	b	field_19233
 FIELD	bsj	Lbqo;	c	field_19234
 FIELD	bsj	Lbqp;	d	field_19235
-CLASS	bsk	net/minecraft/class_3879
+CLASS	bsk	net/minecraft/class_3880
 METHOD	bsk	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbsj;)Z	a	method_17395
 METHOD	bsk	(Lbqo;Lbqp;Laxz;Lbmy;Ljava/util/Random;Lel;)Z	a	method_17396
-CLASS	bsl	net/minecraft/class_3880
+CLASS	bsl	net/minecraft/class_3881
 FIELD	bsl	[Lbqo;	a	field_19236
 FIELD	bsl	[Lbqp;	b	field_19237
 FIELD	bsl	[F	c	field_19238
 FIELD	bsl	Lbqo;	d	field_19239
 FIELD	bsl	Lbqp;	f	field_19240
-CLASS	bsm	net/minecraft/class_3881
+CLASS	bsm	net/minecraft/class_3882
 METHOD	bsm	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbsn;)Z	a	method_17397
 METHOD	bsm	(Lbqo;Lbqp;Laxz;Lbmy;Ljava/util/Random;Lel;)Z	a	method_17398
-CLASS	bsn	net/minecraft/class_3882
+CLASS	bsn	net/minecraft/class_3883
 FIELD	bsn	[Lbqo;	a	field_19241
 FIELD	bsn	[Lbqp;	b	field_19242
 FIELD	bsn	I	c	field_19243
-CLASS	bso	net/minecraft/class_3883
+CLASS	bso	net/minecraft/class_3884
 METHOD	bso	(Lbmy;)I	a	method_17399
 METHOD	bso	(Lbmy;)I	b	method_17400
 METHOD	bso	()I	c	method_17401
-CLASS	bsp	net/minecraft/class_3884
+CLASS	bsp	net/minecraft/class_3885
 METHOD	bsp	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbsl;)Z	a	method_17402
 METHOD	bsp	(Lbqo;Lbqp;Laxz;Lbmy;Ljava/util/Random;Lel;)Z	a	method_17403
 CLASS	bsq	net/minecraft/class_1242
 METHOD	bsq	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17404
-CLASS	bsr	net/minecraft/class_3885
+CLASS	bsr	net/minecraft/class_3886
 FIELD	bsr	Ljava/util/function/Predicate;	a	field_19244
 FIELD	bsr	Lblc;	b	field_19245
-CLASS	bss	net/minecraft/class_3886
+CLASS	bss	net/minecraft/class_3887
 METHOD	bss	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbsr;)Z	a	method_17405
 CLASS	bst	net/minecraft/class_1777
 FIELD	bst	Lblc;	a	field_10166
@@ -13353,36 +13353,36 @@ FIELD	bsu	Lblc;	a	field_10168
 FIELD	bsu	Lblc;	b	field_10169
 METHOD	bsu	(Ljava/util/Set;Laxz;Lel;)V	a	method_17408
 METHOD	bsu	(Laxz;Lel;)V	b	method_17409
-CLASS	bsv	net/minecraft/class_3887
+CLASS	bsv	net/minecraft/class_3888
 METHOD	bsv	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpu;)Z	a	method_17410
-CLASS	bsw	net/minecraft/class_3888
+CLASS	bsw	net/minecraft/class_3889
 METHOD	bsw	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbsx;)Z	a	method_17411
-CLASS	bsx	net/minecraft/class_3889
+CLASS	bsx	net/minecraft/class_3890
 FIELD	bsx	I	a	field_19246
 FIELD	bsx	D	b	field_19247
-CLASS	bsy	net/minecraft/class_3890
+CLASS	bsy	net/minecraft/class_3891
 FIELD	bsy	Z	a	field_19248
-CLASS	bsz	net/minecraft/class_3891
-CLASS	bsz$a	net/minecraft/class_3891$class_3892
-CLASS	bt	net/minecraft/class_3893
+CLASS	bsz	net/minecraft/class_3892
+CLASS	bsz$a	net/minecraft/class_3892$class_3893
+CLASS	bt	net/minecraft/class_3894
 METHOD	bt	()Z	B_	method_17412
 METHOD	bt	()Z	a	method_17413
 METHOD	bt	(Lij;)V	a	method_5505
 METHOD	bt	()Z	b	method_17414
-CLASS	bta	net/minecraft/class_3894
+CLASS	bta	net/minecraft/class_3895
 FIELD	bta	Lblc;	a	field_19249
 FIELD	bta	Ljava/util/List;	b	field_19250
 FIELD	bta	Ljava/util/List;	c	field_19251
 FIELD	bta	Ljava/util/List;	d	field_19252
-CLASS	btb	net/minecraft/class_3895
+CLASS	btb	net/minecraft/class_3896
 METHOD	btb	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbta;)Z	a	method_17415
-CLASS	btc	net/minecraft/class_3896
+CLASS	btc	net/minecraft/class_3897
 FIELD	btc	[Lbqo;	a	field_19253
 FIELD	btc	[Lbqp;	b	field_19254
-CLASS	btd	net/minecraft/class_3897
+CLASS	btd	net/minecraft/class_3898
 METHOD	btd	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbtc;)Z	a	method_17416
 METHOD	btd	(Lbqo;Lbqp;Laxz;Lbmy;Ljava/util/Random;Lel;)Z	a	method_17417
-CLASS	bte	net/minecraft/class_3898
+CLASS	bte	net/minecraft/class_3899
 METHOD	bte	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17418
 CLASS	btf	net/minecraft/class_1244
 FIELD	btf	Z	a	field_12982
@@ -13406,22 +13406,22 @@ METHOD	btf$a	()I	c	method_11829
 METHOD	btf$a	()I	d	method_11830
 METHOD	btf$a	()Z	e	method_11831
 METHOD	btf$a	()Lcea;	f	method_11832
-CLASS	btg	net/minecraft/class_3899
+CLASS	btg	net/minecraft/class_3900
 FIELD	btg	Lbyv;	a	field_19255
 CLASS	bth	net/minecraft/class_1245
 METHOD	bth	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbtg;)Z	a	method_17420
 CLASS	bti	net/minecraft/class_1246
 FIELD	bti	Lblc;	a	field_10170
 FIELD	bti	Lblc;	b	field_19256
-CLASS	btj	net/minecraft/class_3900
-CLASS	btk	net/minecraft/class_3901
+CLASS	btj	net/minecraft/class_3901
+CLASS	btk	net/minecraft/class_3902
 FIELD	btk	Z	b	field_19257
 FIELD	btk	[Laxm;	c	field_19258
 FIELD	btk	J	d	field_19259
 METHOD	btk	(Lbmy;)V	a	method_17421
 METHOD	btk	()V	c	method_17422
-CLASS	btk$a	net/minecraft/class_3901$class_10
-CLASS	btl	net/minecraft/class_3902
+CLASS	btk$a	net/minecraft/class_3902$class_10
+CLASS	btl	net/minecraft/class_3903
 FIELD	btl	Lbxc;	a	field_19260
 FIELD	btl	Lorg/apache/logging/log4j/Logger;	b	field_19261
 METHOD	btl	()Ljava/lang/String;	a	method_17423
@@ -13437,25 +13437,25 @@ METHOD	btl	(Lbmy;Ljava/util/Random;IIII)Laxm;	a	method_17432
 METHOD	btl	()I	b	method_17433
 METHOD	btl	(Laxz;Lel;)Z	b	method_17434
 METHOD	btl	(Laxz;Lel;)Z	c	method_17435
-CLASS	btl$1	net/minecraft/class_3902$1
-CLASS	btm	net/minecraft/class_3903
-CLASS	btn	net/minecraft/class_3904
+CLASS	btl$1	net/minecraft/class_3903$1
+CLASS	btm	net/minecraft/class_3904
+CLASS	btn	net/minecraft/class_3905
 FIELD	btn	Lblc;	a	field_19262
 FIELD	btn	Lblc;	b	field_19263
 METHOD	btn	(Laxz;Lel;Lbmb;)V	a	method_17436
-CLASS	bto	net/minecraft/class_3905
-CLASS	btp	net/minecraft/class_3906
+CLASS	bto	net/minecraft/class_3906
+CLASS	btp	net/minecraft/class_3907
 FIELD	btp	Ljava/util/List;	b	field_19264
 METHOD	btp	(Laxz;Lel;)Z	d	method_17437
-CLASS	btp$a	net/minecraft/class_3906$class_3907
-CLASS	btq	net/minecraft/class_3908
+CLASS	btp$a	net/minecraft/class_3907$class_3908
+CLASS	btq	net/minecraft/class_3909
 METHOD	btq	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17438
 METHOD	btq	(Ljava/util/Random;)Lblc;	a	method_17439
-CLASS	btr	net/minecraft/class_3909
+CLASS	btr	net/minecraft/class_3910
 FIELD	btr	Lblc;	a	field_19265
 CLASS	bts	net/minecraft/class_1248
 METHOD	bts	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbtr;)Z	a	method_17440
-CLASS	btt	net/minecraft/class_3910
+CLASS	btt	net/minecraft/class_3911
 FIELD	btt	Lblc;	aH	field_19266
 FIELD	btt	I	a	field_19267
 FIELD	btt	Lblc;	aI	field_19268
@@ -13466,20 +13466,20 @@ METHOD	btt	(Laxz;ILel;Leq;)V	a	method_17441
 METHOD	btt	(Laxz;Lel;Lbmb;)V	a	method_17442
 METHOD	btt	(Ljava/util/Random;)I	a	method_17443
 METHOD	btt	(Laxz;Lel;Lbmb;)V	b	method_17444
-CLASS	btu	net/minecraft/class_3911
+CLASS	btu	net/minecraft/class_3912
 FIELD	btu	I	a	field_19272
 FIELD	btu	Lbxh$n;	b	field_19273
-CLASS	btv	net/minecraft/class_3912
-CLASS	btv$a	net/minecraft/class_3912$class_38
+CLASS	btv	net/minecraft/class_3913
+CLASS	btv$a	net/minecraft/class_3913$class_38
 FIELD	btv$a	Z	e	field_73
 CLASS	btw	net/minecraft/class_1250
 METHOD	btw	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17445
-CLASS	btx	net/minecraft/class_3913
+CLASS	btx	net/minecraft/class_3914
 METHOD	btx	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17446
 CLASS	bty	net/minecraft/class_1192
 METHOD	bty	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbrz;)Z	a	method_17447
-CLASS	btz	net/minecraft/class_3914
-CLASS	bu	net/minecraft/class_3915
+CLASS	btz	net/minecraft/class_3915
+CLASS	bu	net/minecraft/class_3916
 FIELD	bu	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_19274
 FIELD	bu	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_19275
 FIELD	bu	Lbt;	c	field_19276
@@ -13521,8 +13521,8 @@ METHOD	bu	()Ltf;	h	method_17471
 METHOD	bu	()Lced;	i	method_17472
 METHOD	bu	()Lnet/minecraft/server/MinecraftServer;	j	method_17473
 METHOD	bu	()Lca$a;	k	method_17474
-CLASS	bua	net/minecraft/class_3916
-CLASS	bua$a	net/minecraft/class_3916$class_3071
+CLASS	bua	net/minecraft/class_3917
+CLASS	bua$a	net/minecraft/class_3917$class_3071
 FIELD	bua$a	Z	e	field_15196
 CLASS	buc	net/minecraft/class_1282
 FIELD	buc	Lblc;	a	field_10180
@@ -13533,7 +13533,7 @@ METHOD	buc	(I)V	a	method_4112
 METHOD	buc	()Lblc;	b	method_9229
 METHOD	buc	()I	c	method_4111
 METHOD	buc	()Ljava/lang/String;	toString	toString
-CLASS	bud	net/minecraft/class_3917
+CLASS	bud	net/minecraft/class_3918
 FIELD	bud	Lbpn;	A	field_19288
 FIELD	bud	Lbpn;	B	field_19289
 FIELD	bud	Lbpn;	C	field_19290
@@ -13588,47 +13588,47 @@ METHOD	bud	()Ljava/util/List;	v	method_17499
 METHOD	bud	()V	w	method_17500
 METHOD	bud	()Lbud;	x	method_17501
 METHOD	bud	()Z	y	method_17502
-CLASS	bug	net/minecraft/class_3918
+CLASS	bug	net/minecraft/class_3919
 METHOD	bug	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuv;Lbqo;Lbqp;)Z	a	method_17503
-CLASS	buh	net/minecraft/class_3919
+CLASS	buh	net/minecraft/class_3920
 METHOD	buh	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuw;Lbqo;Lbqp;)Z	a	method_17504
-CLASS	bui	net/minecraft/class_3920
+CLASS	bui	net/minecraft/class_3921
 METHOD	bui	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuw;Lbqo;Lbqp;)Z	a	method_17505
-CLASS	buj	net/minecraft/class_3921
+CLASS	buj	net/minecraft/class_3922
 METHOD	buj	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuw;Lbqo;Lbqp;)Z	a	method_17506
-CLASS	buk	net/minecraft/class_3922
+CLASS	buk	net/minecraft/class_3923
 METHOD	buk	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuw;Lbqo;Lbqp;)Z	a	method_17507
-CLASS	bul	net/minecraft/class_3923
+CLASS	bul	net/minecraft/class_3924
 METHOD	bul	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17508
-CLASS	bum	net/minecraft/class_3924
+CLASS	bum	net/minecraft/class_3925
 METHOD	bum	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpy;Lbqo;Lbqp;)Z	a	method_17509
-CLASS	bun	net/minecraft/class_3925
+CLASS	bun	net/minecraft/class_3926
 METHOD	bun	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbvc;Lbqo;Lbqp;)Z	a	method_17510
-CLASS	buo	net/minecraft/class_3926
+CLASS	buo	net/minecraft/class_3927
 METHOD	buo	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17511
-CLASS	bup	net/minecraft/class_3927
+CLASS	bup	net/minecraft/class_3928
 METHOD	bup	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17512
-CLASS	buq	net/minecraft/class_3928
+CLASS	buq	net/minecraft/class_3929
 METHOD	buq	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17513
-CLASS	bur	net/minecraft/class_3929
+CLASS	bur	net/minecraft/class_3930
 METHOD	bur	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17514
-CLASS	bus	net/minecraft/class_3930
+CLASS	bus	net/minecraft/class_3931
 METHOD	bus	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17515
-CLASS	but	net/minecraft/class_3931
+CLASS	but	net/minecraft/class_3932
 METHOD	but	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpy;Lbqo;Lbqp;)Z	a	method_17516
-CLASS	buu	net/minecraft/class_3932
+CLASS	buu	net/minecraft/class_3933
 METHOD	buu	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuz;Lbqo;Lbqp;)Z	a	method_17517
-CLASS	buv	net/minecraft/class_3933
+CLASS	buv	net/minecraft/class_3934
 FIELD	buv	Lboq$a;	a	field_19313
 FIELD	buv	F	b	field_19314
-CLASS	buw	net/minecraft/class_3934
+CLASS	buw	net/minecraft/class_3935
 FIELD	buw	I	a	field_19315
-CLASS	bux	net/minecraft/class_3935
+CLASS	bux	net/minecraft/class_3936
 FIELD	bux	I	a	field_19316
-CLASS	buy	net/minecraft/class_3936
+CLASS	buy	net/minecraft/class_3937
 FIELD	buy	I	a	field_19317
 FIELD	buy	F	b	field_19318
-CLASS	buz	net/minecraft/class_3937
+CLASS	buz	net/minecraft/class_3938
 FIELD	buz	I	a	field_19319
 FIELD	buz	F	b	field_19320
 FIELD	buz	I	c	field_19321
@@ -13650,72 +13650,72 @@ METHOD	bv	(Ljava/lang/String;)Lcom/mojang/brigadier/builder/LiteralArgumentBuild
 METHOD	bv	(Ljava/lang/String;Lcom/mojang/brigadier/arguments/ArgumentType;)Lcom/mojang/brigadier/builder/RequiredArgumentBuilder;	a	method_17530
 METHOD	bv	(Ljava/lang/String;Lip;)V	a	method_17531
 METHOD	bv	(Ltf;)V	a	method_17532
-CLASS	bv$a	net/minecraft/class_765$class_3938
+CLASS	bv$a	net/minecraft/class_765$class_3939
 METHOD	bv$a	(Lcom/mojang/brigadier/StringReader;)V	parse	parse
-CLASS	bva	net/minecraft/class_3939
+CLASS	bva	net/minecraft/class_3940
 FIELD	bva	I	a	field_19324
 FIELD	bva	D	b	field_19325
-CLASS	bvb	net/minecraft/class_3940
+CLASS	bvb	net/minecraft/class_3941
 FIELD	bvb	I	a	field_19326
 FIELD	bvb	I	b	field_19327
-CLASS	bvc	net/minecraft/class_3941
+CLASS	bvc	net/minecraft/class_3942
 FIELD	bvc	I	a	field_19328
 FIELD	bvc	I	b	field_19329
 FIELD	bvc	I	c	field_19330
-CLASS	bvd	net/minecraft/class_3942
+CLASS	bvd	net/minecraft/class_3943
 METHOD	bvd	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17533
-CLASS	bve	net/minecraft/class_3943
+CLASS	bve	net/minecraft/class_3944
 METHOD	bve	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17534
-CLASS	bvf	net/minecraft/class_3944
+CLASS	bvf	net/minecraft/class_3945
 METHOD	bvf	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17535
-CLASS	bvg	net/minecraft/class_3945
+CLASS	bvg	net/minecraft/class_3946
 METHOD	bvg	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpx;Lbqo;Lbqp;)Z	a	method_17536
 METHOD	bvg	()Ljava/lang/String;	toString	toString
-CLASS	bvh	net/minecraft/class_3946
+CLASS	bvh	net/minecraft/class_3947
 METHOD	bvh	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17537
-CLASS	bvi	net/minecraft/class_3947
+CLASS	bvi	net/minecraft/class_3948
 METHOD	bvi	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbuw;Lbqo;Lbqp;)Z	a	method_17538
-CLASS	bvj	net/minecraft/class_3948
+CLASS	bvj	net/minecraft/class_3949
 FIELD	bvj	I	a	field_19331
-CLASS	bvk	net/minecraft/class_3949
+CLASS	bvk	net/minecraft/class_3950
 METHOD	bvk	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbvj;Lbqo;Lbqp;)Z	a	method_17539
-CLASS	bvl	net/minecraft/class_3950
+CLASS	bvl	net/minecraft/class_3951
 METHOD	bvl	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbvj;Lbqo;Lbqp;)Z	a	method_17540
-CLASS	bvm	net/minecraft/class_3951
+CLASS	bvm	net/minecraft/class_3952
 FIELD	bvm	I	a	field_19332
-CLASS	bvn	net/minecraft/class_3952
+CLASS	bvn	net/minecraft/class_3953
 METHOD	bvn	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbvm;Lbqo;Lbqp;)Z	a	method_17541
-CLASS	bvo	net/minecraft/class_3953
+CLASS	bvo	net/minecraft/class_3954
 METHOD	bvo	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpz;Lbqo;Lbqp;)Z	a	method_17542
-CLASS	bvp	net/minecraft/class_3954
+CLASS	bvp	net/minecraft/class_3955
 METHOD	bvp	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpz;Lbqo;Lbqp;)Z	a	method_17543
-CLASS	bvq	net/minecraft/class_3955
+CLASS	bvq	net/minecraft/class_3956
 METHOD	bvq	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17544
-CLASS	bvr	net/minecraft/class_3956
+CLASS	bvr	net/minecraft/class_3957
 METHOD	bvr	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17545
-CLASS	bvs	net/minecraft/class_3957
+CLASS	bvs	net/minecraft/class_3958
 FIELD	bvs	Lcom/google/common/cache/LoadingCache;	a	field_19333
 METHOD	bvs	(Laxz;)[Lbtf$a;	a	method_17546
 METHOD	bvs	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17547
-CLASS	bvs$1	net/minecraft/class_3957$1
-CLASS	bvs$a	net/minecraft/class_3957$class_2715
+CLASS	bvs$1	net/minecraft/class_3958$1
+CLASS	bvs$a	net/minecraft/class_3958$class_2715
 METHOD	bvs$a	(Ljava/lang/Long;)[Lbtf$a;	a	method_11546
 METHOD	bvs$a	(Ljava/lang/Object;)Ljava/lang/Object;	load	load
-CLASS	bvt	net/minecraft/class_3958
+CLASS	bvt	net/minecraft/class_3959
 METHOD	bvt	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbry;Lbqo;Lbqp;)Z	a	method_17548
-CLASS	bvu	net/minecraft/class_3959
+CLASS	bvu	net/minecraft/class_3960
 METHOD	bvu	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbva;Lbqo;Lbqp;)Z	a	method_17549
-CLASS	bvv	net/minecraft/class_3960
+CLASS	bvv	net/minecraft/class_3961
 METHOD	bvv	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbvb;Lbqo;Lbqp;)Z	a	method_17550
-CLASS	bvw	net/minecraft/class_3961
+CLASS	bvw	net/minecraft/class_3962
 METHOD	bvw	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpw;Lbqo;Lbqp;)Z	a	method_17551
-CLASS	bvx	net/minecraft/class_3962
+CLASS	bvx	net/minecraft/class_3963
 METHOD	bvx	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpy;Lbqo;Lbqp;)Z	a	method_17552
-CLASS	bvy	net/minecraft/class_3963
+CLASS	bvy	net/minecraft/class_3964
 METHOD	bvy	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17553
-CLASS	bvz	net/minecraft/class_3964
+CLASS	bvz	net/minecraft/class_3965
 METHOD	bvz	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17554
-CLASS	bw	net/minecraft/class_3965
+CLASS	bw	net/minecraft/class_3966
 METHOD	bw	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	a	method_17555
 METHOD	bw	(Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/lang/String;Lpc;)V	a	method_17556
 METHOD	bw	(Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/util/function/Function;Ljava/util/function/Function;Ljava/lang/Object;)V	a	method_17557
@@ -13742,17 +13742,17 @@ METHOD	bw	()Ljava/util/Collection;	m	method_17577
 METHOD	bw	()Ljava/util/Collection;	n	method_17578
 METHOD	bw	()Ljava/util/Collection;	o	method_17579
 METHOD	bw	()Ljava/util/Collection;	p	method_17580
-CLASS	bw$a	net/minecraft/class_3965$class_3966
+CLASS	bw$a	net/minecraft/class_3966$class_3967
 FIELD	bw$a	Lbw$a;	a	field_19334
 FIELD	bw$a	Lbw$a;	b	field_19335
 FIELD	bw$a	Ljava/lang/String;	c	field_19336
 FIELD	bw$a	Ljava/lang/String;	d	field_19337
 FIELD	bw$a	Ljava/lang/String;	e	field_19338
-CLASS	bwa	net/minecraft/class_3967
+CLASS	bwa	net/minecraft/class_3968
 METHOD	bwa	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbux;Lbqo;Lbqp;)Z	a	method_17581
-CLASS	bwb	net/minecraft/class_3968
+CLASS	bwb	net/minecraft/class_3969
 METHOD	bwb	(Laxz;Lbmy;Ljava/util/Random;Lel;Lbpy;Lbqo;Lbqp;)Z	a	method_17582
-CLASS	bwe	net/minecraft/class_3969
+CLASS	bwe	net/minecraft/class_3970
 FIELD	bwe	Lblc;	a	field_19339
 FIELD	bwe	Lblc;	b	field_19340
 FIELD	bwe	Lbyw;	c	field_19341
@@ -13791,24 +13791,24 @@ CLASS	bwf$1	net/minecraft/class_1251$1
 FIELD	bwf$1	[I	a	field_10181
 CLASS	bwg	net/minecraft/class_1588
 METHOD	bwg	()V	a	method_5511
-CLASS	bwg$a	net/minecraft/class_1588$class_3970
+CLASS	bwg$a	net/minecraft/class_1588$class_3971
 METHOD	bwg$a	(Lblc;)Z	a	method_17590
-CLASS	bwh	net/minecraft/class_3971
+CLASS	bwh	net/minecraft/class_3972
 FIELD	bwh	[F	g	field_19345
 METHOD	bwh	(Laxk;Ljava/util/Random;IILbsh;)Z	a	method_17591
 METHOD	bwh	(Laxz;JIIDDDFFFIIDLjava/util/BitSet;)V	a	method_17592
 METHOD	bwh	(Laxz;Ljava/util/Random;IIIILjava/util/BitSet;Lbsh;)Z	a	method_17593
-CLASS	bwi	net/minecraft/class_3972
+CLASS	bwi	net/minecraft/class_3973
 METHOD	bwi	(Laxk;Ljava/util/Random;IILbsh;)Z	a	method_17594
 METHOD	bwi	(Laxz;JIIDDDFDLjava/util/BitSet;)V	a	method_17595
 METHOD	bwi	(Laxz;JIIDDDFFFIIDLjava/util/BitSet;)V	a	method_17596
 METHOD	bwi	(Laxz;Ljava/util/Random;IIIILjava/util/BitSet;Lbsh;)Z	a	method_17597
-CLASS	bwj	net/minecraft/class_3973
+CLASS	bwj	net/minecraft/class_3974
 FIELD	bwj	Lbxj;	a	field_19346
 FIELD	bwj	Lbqp;	b	field_19347
 METHOD	bwj	(Laxk;Ljava/util/Random;IILbrz;)Z	a	method_17598
 METHOD	bwj	(Laxz;Ljava/util/Random;IIIILjava/util/BitSet;Lbrz;)Z	a	method_17599
-CLASS	bwk	net/minecraft/class_3974
+CLASS	bwk	net/minecraft/class_3975
 FIELD	bwk	[Z	e	field_19348
 METHOD	bwk	()V	ac_	method_17600
 CLASS	bwl	net/minecraft/class_2759
@@ -13849,8 +13849,8 @@ METHOD	bwl$a	(Lbxm;)V	a	method_13773
 CLASS	bwl$b	net/minecraft/class_2759$class_1926
 METHOD	bwl$b	()V	a	method_10465
 METHOD	bwl$b	(Lbxm;ILbwl$a;Lel;Ljava/util/List;Ljava/util/Random;)Z	a	method_11849
-CLASS	bwm	net/minecraft/class_3975
-CLASS	bwn	net/minecraft/class_3976
+CLASS	bwm	net/minecraft/class_3976
+CLASS	bwn	net/minecraft/class_3977
 FIELD	bwn	Lpc;	a	field_19349
 FIELD	bwn	Lpc;	b	field_19350
 FIELD	bwn	Lpc;	c	field_19351
@@ -13861,20 +13861,20 @@ METHOD	bwn	(Lbxm;Lel;Lbhb;Ljava/util/List;Ljava/util/Random;Lbrf;)V	a	method_176
 METHOD	bwn	()Ljava/util/Map;	b	method_17603
 METHOD	bwn	()Ljava/util/Map;	c	method_17604
 METHOD	bwn	()Lpc;	d	method_17605
-CLASS	bwn$a	net/minecraft/class_3976$class_3977
+CLASS	bwn$a	net/minecraft/class_3977$class_3978
 FIELD	bwn$a	Lpc;	d	field_19354
 FIELD	bwn$a	Lbhb;	e	field_19355
 METHOD	bwn$a	(Lbxm;)V	a	method_17606
-CLASS	bwo	net/minecraft/class_3978
+CLASS	bwo	net/minecraft/class_3979
 FIELD	bwo	Z	e	field_19356
 FIELD	bwo	Z	f	field_19357
 FIELD	bwo	Z	g	field_19358
 FIELD	bwo	Z	h	field_19359
 FIELD	bwo	Lbwo$a;	i	field_19360
 METHOD	bwo	()V	ad_	method_17607
-CLASS	bwo$1	net/minecraft/class_3978$1
-CLASS	bwo$a	net/minecraft/class_3978$class_7
-CLASS	bwp	net/minecraft/class_3979
+CLASS	bwo$1	net/minecraft/class_3979$1
+CLASS	bwo$a	net/minecraft/class_3979$class_7
+CLASS	bwp	net/minecraft/class_3980
 FIELD	bwp	Lorg/apache/logging/log4j/Logger;	a	field_19361
 FIELD	bwp	Ljava/util/Map;	b	field_19362
 FIELD	bwp	Ljava/util/Map;	c	field_19363
@@ -13893,12 +13893,12 @@ METHOD	bwp	(Ljava/lang/String;)Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;	a	me
 METHOD	bwp	(Ljava/util/HashMap;)V	a	method_17617
 METHOD	bwp	()[Ljava/lang/String;	b	method_17618
 METHOD	bwp	(Ljava/util/HashMap;)V	b	method_17619
-CLASS	bwp$a	net/minecraft/class_3979$class_3980
+CLASS	bwp$a	net/minecraft/class_3980$class_3981
 FIELD	bwp$a	[Ljava/lang/String;	a	field_19367
-CLASS	bwp$b	net/minecraft/class_3979$class_3981
+CLASS	bwp$b	net/minecraft/class_3980$class_3982
 FIELD	bwp$b	[Ljava/lang/String;	a	field_19368
 FIELD	bwp$b	[Ljava/lang/String;	b	field_19369
-CLASS	bwp$c	net/minecraft/class_3979$class_3982
+CLASS	bwp$c	net/minecraft/class_3980$class_3983
 FIELD	bwp$c	[Ljava/lang/String;	a	field_19370
 CLASS	bwq	net/minecraft/class_1253
 METHOD	bwq	()V	a	method_5508
@@ -14069,15 +14069,15 @@ METHOD	bws$v	(Lbws$v;Z)Z	b	method_17625
 METHOD	bws$v	()I	c	method_9263
 METHOD	bws$v	(Lbws$v;)[Lbws$v;	c	method_17626
 METHOD	bws$v	(Lbws$v;)[Z	d	method_17627
-CLASS	bwt	net/minecraft/class_3983
-CLASS	bwt$a	net/minecraft/class_3983$class_3984
-CLASS	bwt$b	net/minecraft/class_3983$class_3985
+CLASS	bwt	net/minecraft/class_3984
+CLASS	bwt$a	net/minecraft/class_3984$class_3985
+CLASS	bwt$b	net/minecraft/class_3984$class_3986
 FIELD	bwt$b	Lbwt$b;	a	field_19379
 FIELD	bwt$b	Lbwt$b;	b	field_19380
 FIELD	bwt$b	[Lbwt$b;	c	field_19381
 METHOD	bwt$b	(Ljava/lang/String;)Lbwt$b;	valueOf	valueOf
 METHOD	bwt$b	()[Lbwt$b;	values	values
-CLASS	bwu	net/minecraft/class_3986
+CLASS	bwu	net/minecraft/class_3987
 FIELD	bwu	[Lpc;	a	field_19382
 FIELD	bwu	[Lpc;	b	field_19383
 FIELD	bwu	[Lpc;	c	field_19384
@@ -14093,7 +14093,7 @@ METHOD	bwu	(Lbxm;Ljava/util/Random;Lbhb;Lel;Lbsc;Ljava/util/List;)V	a	method_176
 METHOD	bwu	(Ljava/util/Random;)Lpc;	a	method_17632
 METHOD	bwu	(Ljava/util/Random;II)Ljava/util/List;	a	method_17633
 METHOD	bwu	(Ljava/util/Random;)Lpc;	b	method_17634
-CLASS	bwu$a	net/minecraft/class_3986$class_3987
+CLASS	bwu$a	net/minecraft/class_3987$class_3988
 FIELD	bwu$a	Lbwt$b;	d	field_19390
 FIELD	bwu$a	F	e	field_19391
 FIELD	bwu$a	Lpc;	f	field_19392
@@ -14107,14 +14107,14 @@ FIELD	bwv	I	b	field_15
 FIELD	bwv	I	c	field_16
 FIELD	bwv	I	d	field_17
 METHOD	bwv	(Laxz;Lbwf;I)Z	a	method_16
-CLASS	bww	net/minecraft/class_3988
+CLASS	bww	net/minecraft/class_3989
 FIELD	bww	Lel;	a	field_19395
 FIELD	bww	[Lpc;	b	field_19396
 FIELD	bww	[Lpc;	c	field_19397
 METHOD	bww	()V	a	method_17637
 METHOD	bww	(Lbxm;Lel;Lbhb;Ljava/util/List;Ljava/util/Random;Lbsy;)V	a	method_17638
 METHOD	bww	()Lel;	b	method_17639
-CLASS	bww$a	net/minecraft/class_3988$class_3989
+CLASS	bww$a	net/minecraft/class_3989$class_3990
 FIELD	bww$a	Lbhb;	d	field_19398
 FIELD	bww$a	Lpc;	e	field_19399
 FIELD	bww$a	Z	f	field_19400
@@ -14214,7 +14214,7 @@ METHOD	bwy	(Lgy;Laxz;)Lbxc;	a	method_17641
 METHOD	bwy	(Ljava/lang/Class;Ljava/lang/String;)V	a	method_5521
 METHOD	bwy	(Lgy;Laxz;)Lbxb;	b	method_5522
 METHOD	bwy	(Ljava/lang/Class;Ljava/lang/String;)V	b	method_5523
-CLASS	bwz	net/minecraft/class_3990
+CLASS	bwz	net/minecraft/class_3991
 FIELD	bwz	Lit/unimi/dsi/fastutil/longs/LongSet;	a	field_19401
 FIELD	bwz	Lit/unimi/dsi/fastutil/longs/LongSet;	b	field_19402
 METHOD	bwz	()Lit/unimi/dsi/fastutil/longs/LongSet;	a	method_17642
@@ -14222,7 +14222,7 @@ METHOD	bwz	(J)V	a	method_17643
 METHOD	bwz	(J)Z	b	method_17644
 METHOD	bwz	(J)Z	c	method_17645
 METHOD	bwz	(J)V	d	method_17646
-CLASS	bx	net/minecraft/class_3991
+CLASS	bx	net/minecraft/class_3992
 FIELD	bx	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_19403
 FIELD	bx	Ljava/util/Collection;	b	field_19404
 METHOD	bx	()Lbx;	a	method_17647
@@ -14278,7 +14278,7 @@ CLASS	bxb$a	net/minecraft/class_34$class_35
 FIELD	bxb$a	Lblc;	a	field_10228
 METHOD	bxb$a	()Lblc;	a	method_9276
 METHOD	bxb$a	(Ljava/util/Random;IIIZ)V	a	method_77
-CLASS	bxc	net/minecraft/class_3992
+CLASS	bxc	net/minecraft/class_3993
 FIELD	bxc	Ljava/util/List;	a	field_19407
 FIELD	bxc	Lbwf;	b	field_19408
 FIELD	bxc	I	c	field_19409
@@ -14303,7 +14303,7 @@ METHOD	bxc	()I	f	method_17667
 METHOD	bxc	()Z	g	method_17668
 METHOD	bxc	()V	h	method_17669
 METHOD	bxc	()I	i	method_17670
-CLASS	bxd	net/minecraft/class_3993
+CLASS	bxd	net/minecraft/class_3994
 FIELD	bxd	Z	e	field_19413
 METHOD	bxd	()V	b	method_17671
 CLASS	bxe	net/minecraft/class_2762
@@ -14317,9 +14317,9 @@ METHOD	bxe	()V	b	method_11858
 CLASS	bxe$1	net/minecraft/class_2762$1
 FIELD	bxe$1	[I	a	field_13020
 FIELD	bxe$1	[I	b	field_15191
-CLASS	bxf	net/minecraft/class_3994
+CLASS	bxf	net/minecraft/class_3995
 FIELD	bxf	[F	g	field_19414
-CLASS	bxg	net/minecraft/class_3995
+CLASS	bxg	net/minecraft/class_3996
 CLASS	bxh	net/minecraft/class_39
 METHOD	bxh	()V	a	method_5537
 METHOD	bxh	(Lbxh$k;Lbxh$e;Ljava/util/List;Ljava/util/Random;IIILeq;I)Lbxh$o;	a	method_86
@@ -14380,7 +14380,7 @@ FIELD	bxh$l	I	a	field_99
 METHOD	bxh$l	(Lbxh$k;Ljava/util/List;Ljava/util/Random;IIILeq;)Lbwf;	a	method_106
 CLASS	bxh$m	net/minecraft/class_39$class_52
 METHOD	bxh$m	(Lbxh$k;Ljava/util/List;Ljava/util/Random;IIILeq;I)Lbxh$m;	a	method_107
-CLASS	bxh$n	net/minecraft/class_39$class_3996
+CLASS	bxh$n	net/minecraft/class_39$class_3997
 FIELD	bxh$n	Lbxh$n;	a	field_19421
 FIELD	bxh$n	Lbxh$n;	b	field_19422
 FIELD	bxh$n	Lbxh$n;	c	field_19423
@@ -14480,13 +14480,13 @@ FIELD	bxi$i	Ljava/lang/String;	d	field_15214
 FIELD	bxi$i	Lbhb;	e	field_15215
 FIELD	bxi$i	Lbfz;	f	field_15216
 METHOD	bxi$i	(Lbxm;)V	a	method_13816
-CLASS	bxj	net/minecraft/class_3997
+CLASS	bxj	net/minecraft/class_3998
 METHOD	bxj	(Laxk;Ljava/util/Random;IILbqp;)Z	a	method_17679
 METHOD	bxj	(Laxz;Ljava/util/Random;IIIILjava/util/BitSet;Lbqp;)Z	a	method_17680
 CLASS	bxl	net/minecraft/class_3016
 FIELD	bxl	F	a	field_14873
 FIELD	bxl	Ljava/util/Random;	b	field_14874
-CLASS	bxm	net/minecraft/class_3998
+CLASS	bxm	net/minecraft/class_3999
 FIELD	bxm	Lorg/apache/logging/log4j/Logger;	a	field_19428
 FIELD	bxm	Ljava/util/Map;	b	field_19429
 FIELD	bxm	Lcom/mojang/datafixers/DataFixer;	c	field_19430
@@ -14542,7 +14542,7 @@ METHOD	bxn	()Lbwf;	j	method_11877
 METHOD	bxn	()Z	k	method_11878
 METHOD	bxn	()V	l	method_11879
 METHOD	bxn	()Z	m	method_17694
-CLASS	bxo	net/minecraft/class_3999
+CLASS	bxo	net/minecraft/class_4000
 METHOD	bxo	(Laxk;Lel;Lbxp$b;)Lbxp$b;	a	method_13390
 CLASS	bxp	net/minecraft/class_2765
 FIELD	bxp	Ljava/util/List;	a	field_13031
@@ -14593,19 +14593,19 @@ CLASS	bxp$c	net/minecraft/class_2765$class_2767
 FIELD	bxp$c	Lcee;	a	field_14884
 FIELD	bxp$c	Lel;	b	field_14885
 FIELD	bxp$c	Lgy;	c	field_14886
-CLASS	bxr	net/minecraft/class_4000
+CLASS	bxr	net/minecraft/class_4001
 FIELD	bxr	Lbyc;	a	field_19437
 FIELD	bxr	Lbye;	b	field_19438
 METHOD	bxr	()Lbye;	a	method_17700
 METHOD	bxr	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17701
-CLASS	bxs	net/minecraft/class_4001
+CLASS	bxs	net/minecraft/class_4002
 METHOD	bxs	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17702
 METHOD	bxs	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;Lblc;Lblc;Lblc;I)V	a	method_17703
-CLASS	bxt	net/minecraft/class_4002
+CLASS	bxt	net/minecraft/class_4003
 METHOD	bxt	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17704
-CLASS	bxu	net/minecraft/class_4003
+CLASS	bxu	net/minecraft/class_4004
 METHOD	bxu	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17705
-CLASS	bxv	net/minecraft/class_4004
+CLASS	bxv	net/minecraft/class_4005
 FIELD	bxv	Lblc;	a	field_19439
 FIELD	bxv	Lblc;	b	field_19440
 FIELD	bxv	Lblc;	c	field_19441
@@ -14615,15 +14615,15 @@ FIELD	bxv	Lbyk;	f	field_19444
 FIELD	bxv	Lbyk;	g	field_19445
 FIELD	bxv	J	h	field_19446
 METHOD	bxv	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17706
-CLASS	bxw	net/minecraft/class_4005
+CLASS	bxw	net/minecraft/class_4006
 FIELD	bxw	Lblc;	f	field_19447
 FIELD	bxw	Lblc;	g	field_19448
 FIELD	bxw	Lblc;	h	field_19449
-CLASS	bxx	net/minecraft/class_4006
+CLASS	bxx	net/minecraft/class_4007
 FIELD	bxx	Lblc;	f	field_19450
 FIELD	bxx	Lblc;	g	field_19451
 FIELD	bxx	Lblc;	h	field_19452
-CLASS	bxy	net/minecraft/class_4007
+CLASS	bxy	net/minecraft/class_4008
 FIELD	bxy	[Lblc;	a	field_19453
 FIELD	bxy	J	b	field_19454
 FIELD	bxy	Lbyk;	c	field_19455
@@ -14639,7 +14639,7 @@ FIELD	bxy	Lblc;	l	field_19464
 METHOD	bxy	(III)Lblc;	a	method_17707
 METHOD	bxy	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17708
 METHOD	bxy	(J)V	b	method_17709
-CLASS	bxz	net/minecraft/class_4008
+CLASS	bxz	net/minecraft/class_4009
 FIELD	bxz	J	a	field_19465
 FIELD	bxz	Lbyj;	b	field_19466
 FIELD	bxz	Lblc;	c	field_19467
@@ -14647,7 +14647,7 @@ FIELD	bxz	Lblc;	d	field_19468
 FIELD	bxz	Lblc;	e	field_19469
 FIELD	bxz	Lblc;	f	field_19470
 METHOD	bxz	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17710
-CLASS	by	net/minecraft/class_4009
+CLASS	by	net/minecraft/class_4010
 FIELD	by	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_19471
 FIELD	by	Ljava/util/Collection;	b	field_19472
 METHOD	by	()Lby;	a	method_17711
@@ -14656,24 +14656,24 @@ METHOD	by	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lij;	
 METHOD	by	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	a	method_17714
 METHOD	by	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	by	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	bya	net/minecraft/class_4010
+CLASS	bya	net/minecraft/class_4011
 METHOD	bya	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17715
-CLASS	byb	net/minecraft/class_4011
+CLASS	byb	net/minecraft/class_4012
 METHOD	byb	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17716
-CLASS	byc	net/minecraft/class_4012
+CLASS	byc	net/minecraft/class_4013
 METHOD	byc	(J)V	a	method_17717
 METHOD	byc	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbye;)V	a	method_17718
-CLASS	byd	net/minecraft/class_4013
+CLASS	byd	net/minecraft/class_4014
 FIELD	byd	Lblc;	a	field_19473
 FIELD	byd	Lblc;	b	field_19474
 FIELD	byd	Lblc;	c	field_19475
 METHOD	byd	()Lblc;	c	method_17719
-CLASS	bye	net/minecraft/class_4014
+CLASS	bye	net/minecraft/class_4015
 METHOD	bye	()Lblc;	a	method_17720
 METHOD	bye	()Lblc;	b	method_17721
-CLASS	byf	net/minecraft/class_4015
+CLASS	byf	net/minecraft/class_4016
 METHOD	byf	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17722
-CLASS	byg	net/minecraft/class_4016
+CLASS	byg	net/minecraft/class_4017
 METHOD	byg	(Ljava/util/Random;Lbmx;Layu;IIIDLblc;Lblc;IJLbyd;)V	a	method_17723
 CLASS	byi	net/minecraft/class_1779
 FIELD	byi	D	a	field_7548
@@ -14718,7 +14718,7 @@ METHOD	byl	(DD)D	a	method_6583
 METHOD	byl	([DDDIIDDD)V	a	method_6584
 METHOD	byl	([IDD)D	a	method_6585
 CLASS	bym	net/minecraft/class_59
-CLASS	byo	net/minecraft/class_4017
+CLASS	byo	net/minecraft/class_4018
 FIELD	byo	Lorg/apache/logging/log4j/Logger;	a	field_19476
 FIELD	byo	[Leq;	b	field_19477
 FIELD	byo	Lit/unimi/dsi/fastutil/ints/IntPriorityQueue;	c	field_19478
@@ -14735,15 +14735,15 @@ METHOD	byo	(Laxk;Lel;)I	b	method_17737
 METHOD	byo	(I)I	c	method_17738
 METHOD	byo	(I)I	d	method_17739
 METHOD	byo	(I)Leq;	e	method_17740
-CLASS	byp	net/minecraft/class_4018
+CLASS	byp	net/minecraft/class_4019
 METHOD	byp	(Lti;Lbmx;)V	a	method_17741
-CLASS	byq	net/minecraft/class_4019
+CLASS	byq	net/minecraft/class_4020
 METHOD	byq	()Layi;	a	method_17742
-CLASS	byr	net/minecraft/class_4020
+CLASS	byr	net/minecraft/class_4021
 FIELD	byr	[Leq;	a	field_19479
 METHOD	byr	(Lti;Lbmx;)V	a	method_17743
-CLASS	byt	net/minecraft/class_4021
-CLASS	byu	net/minecraft/class_4022
+CLASS	byt	net/minecraft/class_4022
+CLASS	byu	net/minecraft/class_4023
 FIELD	byu	Lbmb;	a	field_19480
 FIELD	byu	Lbmj;	b	field_19481
 FIELD	byu	Ljava/lang/ThreadLocal;	e	field_19482
@@ -14778,9 +14778,9 @@ METHOD	byu	()Z	g	method_17771
 METHOD	byu	(Lbyw;)Z	g	method_17772
 METHOD	byu	(Lbyw;)Z	h	method_17773
 METHOD	byu	()Lit/unimi/dsi/fastutil/objects/Object2ByteLinkedOpenHashMap;	m	method_17774
-CLASS	byu$1	net/minecraft/class_4022$1
+CLASS	byu$1	net/minecraft/class_4023$1
 METHOD	byu$1	(I)V	rehash	rehash
-CLASS	byv	net/minecraft/class_4023
+CLASS	byv	net/minecraft/class_4024
 FIELD	byv	Lbyw;	a	field_19483
 FIELD	byv	Leu;	c	field_19484
 FIELD	byv	Lble;	d	field_19485
@@ -14809,7 +14809,7 @@ METHOD	byv	()Lbyw;	i	method_17796
 METHOD	byv	()Lfk;	j	method_17797
 METHOD	byv	()Z	k	method_17798
 METHOD	byv	()V	l	method_17799
-CLASS	byw	net/minecraft/class_4024
+CLASS	byw	net/minecraft/class_4025
 METHOD	byw	(Laxk;Lel;)Z	a	method_17800
 METHOD	byw	(Laxy;Lel;)V	a	method_17801
 METHOD	byw	(Laxy;Lel;Ljava/util/Random;)V	a	method_17802
@@ -14827,8 +14827,8 @@ METHOD	byw	()Lblc;	i	method_17813
 METHOD	byw	()Lfk;	j	method_17814
 METHOD	byw	()Laxl;	k	method_17815
 METHOD	byw	()F	l	method_17816
-CLASS	byx	net/minecraft/class_4025
-CLASS	byy	net/minecraft/class_4026
+CLASS	byx	net/minecraft/class_4026
+CLASS	byy	net/minecraft/class_4027
 FIELD	byy	Lbyv;	a	field_19486
 FIELD	byy	Lbyu;	b	field_19487
 FIELD	byy	Lbyu;	c	field_19488
@@ -14836,13 +14836,13 @@ FIELD	byy	Lbyu;	d	field_19489
 FIELD	byy	Lbyu;	e	field_19490
 FIELD	byy	Ljava/util/Set;	f	field_19491
 METHOD	byy	(Ljava/lang/String;)Lbyv;	a	method_17817
-CLASS	byz	net/minecraft/class_4027
+CLASS	byz	net/minecraft/class_4028
 METHOD	byz	(Laxz;Lel;)V	a	method_17818
 METHOD	byz	(Layc;Lel;)Z	a	method_17819
 METHOD	byz	(Layc;Lel;)Z	b	method_17820
-CLASS	byz$a	net/minecraft/class_4027$class_4028
-CLASS	byz$b	net/minecraft/class_4027$class_4029
-CLASS	bz	net/minecraft/class_4030
+CLASS	byz$a	net/minecraft/class_4028$class_4029
+CLASS	byz$b	net/minecraft/class_4028$class_4030
+CLASS	bz	net/minecraft/class_4031
 FIELD	bz	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_19492
 FIELD	bz	Ljava/util/Collection;	b	field_19493
 METHOD	bz	()Lbz;	a	method_17821
@@ -14911,7 +14911,7 @@ METHOD	bza	()Z	f	method_132
 METHOD	bza	()Z	g	method_133
 METHOD	bza	()Lbzc;	h	method_134
 METHOD	bza	()Lbzb;	i	method_6586
-CLASS	bza$a	net/minecraft/class_63$class_4031
+CLASS	bza$a	net/minecraft/class_63$class_4032
 FIELD	bza$a	Lbzc;	a	field_19501
 FIELD	bza$a	Z	b	field_19502
 FIELD	bza$a	Z	c	field_19503
@@ -14998,12 +14998,12 @@ FIELD	bzc	Lbzc;	e	field_15855
 FIELD	bzc	[Lbzc;	f	field_13049
 METHOD	bzc	(Ljava/lang/String;)Lbzc;	valueOf	valueOf
 METHOD	bzc	()[Lbzc;	values	values
-CLASS	bzd	net/minecraft/class_4032
-CLASS	bzd$a	net/minecraft/class_4032$class_4033
-CLASS	bzd$b	net/minecraft/class_4032$class_4034
-CLASS	bzf	net/minecraft/class_4035
+CLASS	bzd	net/minecraft/class_4033
+CLASS	bzd$a	net/minecraft/class_4033$class_4034
+CLASS	bzd$b	net/minecraft/class_4033$class_4035
+CLASS	bzf	net/minecraft/class_4036
 METHOD	bzf	(II)I	a	method_17837
-CLASS	bzg	net/minecraft/class_4036
+CLASS	bzg	net/minecraft/class_4037
 FIELD	bzg	I	a	field_19535
 FIELD	bzg	I	b	field_19536
 FIELD	bzg	I	c	field_19537
@@ -15012,31 +15012,31 @@ METHOD	bzg	()I	a	method_17838
 METHOD	bzg	()I	b	method_17839
 METHOD	bzg	()I	c	method_17840
 METHOD	bzg	()I	d	method_17841
-CLASS	bzh	net/minecraft/class_4037
+CLASS	bzh	net/minecraft/class_4038
 METHOD	bzh	(Lbzg;)Lbzf;	make	make
-CLASS	bzi	net/minecraft/class_4038
+CLASS	bzi	net/minecraft/class_4039
 FIELD	bzi	Lcaw;	a	field_19539
 FIELD	bzi	Lit/unimi/dsi/fastutil/longs/Long2IntLinkedOpenHashMap;	b	field_19540
 FIELD	bzi	I	c	field_19541
 FIELD	bzi	Lbzg;	d	field_19542
 METHOD	bzi	()I	a	method_17842
 METHOD	bzi	(II)J	b	method_17843
-CLASS	bzk	net/minecraft/class_4039
+CLASS	bzk	net/minecraft/class_4040
 METHOD	bzk	(JJ)V	a	method_17844
 METHOD	bzk	(Lbzg;Lcaw;)Lbzf;	a	method_17845
 METHOD	bzk	(Lbzg;Lcaw;Lbzf;)Lbzf;	a	method_17846
 METHOD	bzk	(Lbzg;Lcaw;Lbzf;Lbzf;)Lbzf;	a	method_17847
 METHOD	bzk	([I)I	a	method_17848
-CLASS	bzl	net/minecraft/class_4040
+CLASS	bzl	net/minecraft/class_4041
 METHOD	bzl	()Lbyi;	a	method_17849
 METHOD	bzl	(I)I	a	method_17850
-CLASS	bzm	net/minecraft/class_4041
+CLASS	bzm	net/minecraft/class_4042
 FIELD	bzm	J	a	field_19543
 FIELD	bzm	Lbyi;	b	field_19544
 FIELD	bzm	J	c	field_19545
 FIELD	bzm	J	d	field_19546
 METHOD	bzm	(J)V	a	method_17851
-CLASS	bzn	net/minecraft/class_4042
+CLASS	bzn	net/minecraft/class_4043
 FIELD	bzn	Lit/unimi/dsi/fastutil/longs/Long2IntLinkedOpenHashMap;	c	field_19547
 FIELD	bzn	I	d	field_19548
 FIELD	bzn	I	e	field_19549
@@ -15049,17 +15049,17 @@ FIELD	bzp	[Lbzp;	b	field_19551
 METHOD	bzp	(Ljava/lang/String;)Lbzp;	valueOf	valueOf
 METHOD	bzp	()[Lbzp;	values	values
 CLASS	bzq	net/minecraft/class_1782
-CLASS	bzq$a	net/minecraft/class_1782$class_4043
+CLASS	bzq$a	net/minecraft/class_1782$class_4044
 FIELD	bzq$a	Lbzq$a;	a	field_19552
 FIELD	bzq$a	[Lbzq$a;	b	field_19553
 METHOD	bzq$a	(Ljava/lang/String;)Lbzq$a;	valueOf	valueOf
 METHOD	bzq$a	()[Lbzq$a;	values	values
-CLASS	bzq$b	net/minecraft/class_1782$class_4044
+CLASS	bzq$b	net/minecraft/class_1782$class_4045
 FIELD	bzq$b	Lbzq$b;	a	field_19554
 FIELD	bzq$b	[Lbzq$b;	b	field_19555
 METHOD	bzq$b	(Ljava/lang/String;)Lbzq$b;	valueOf	valueOf
 METHOD	bzq$b	()[Lbzq$b;	values	values
-CLASS	bzq$c	net/minecraft/class_1782$class_4045
+CLASS	bzq$c	net/minecraft/class_1782$class_4046
 FIELD	bzq$c	Lbzq$c;	a	field_19556
 FIELD	bzq$c	[Lbzq$c;	b	field_19557
 METHOD	bzq$c	(Ljava/lang/String;)Lbzq$c;	valueOf	valueOf
@@ -15135,7 +15135,7 @@ METHOD	bzw	()[Lbzw;	values	values
 CLASS	bzx	net/minecraft/class_75
 FIELD	bzx	Lbzh;	a	field_19606
 METHOD	bzx	(IIIILayu;)[Layu;	a	method_17856
-CLASS	bzy	net/minecraft/class_4046
+CLASS	bzy	net/minecraft/class_4047
 FIELD	bzy	I	a	field_19607
 FIELD	bzy	I	b	field_19608
 FIELD	bzy	I	c	field_19609
@@ -15153,7 +15153,7 @@ METHOD	bzy	(JLcan;Lbzh;ILjava/util/function/LongFunction;)Lbzh;	a	method_17860
 METHOD	bzy	(Layg;Lbou;Ljava/util/function/LongFunction;)Lcom/google/common/collect/ImmutableList;	a	method_17861
 METHOD	bzy	([IJJ)Lbzn;	a	method_17862
 METHOD	bzy	(I)Z	b	method_17863
-CLASS	bzz	net/minecraft/class_4047
+CLASS	bzz	net/minecraft/class_4048
 FIELD	bzz	Lbzz;	a	field_19617
 FIELD	bzz	[Lbzz;	b	field_19618
 METHOD	bzz	(Ljava/lang/String;)Lbzz;	valueOf	valueOf
@@ -15181,7 +15181,7 @@ FIELD	c$a	Ljava/lang/String;	a	field_5366
 FIELD	c$a	Ljava/lang/String;	b	field_5367
 METHOD	c$a	()Ljava/lang/String;	a	method_4518
 METHOD	c$a	()Ljava/lang/String;	b	method_4519
-CLASS	ca	net/minecraft/class_4048
+CLASS	ca	net/minecraft/class_4049
 FIELD	ca	Ljava/util/Collection;	a	field_19619
 FIELD	ca	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_19620
 METHOD	ca	()Lca;	a	method_17865
@@ -15191,7 +15191,7 @@ METHOD	ca	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	a	method_17868
 METHOD	ca	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	ca	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	ca	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	ca$a	net/minecraft/class_4048$class_4049
+CLASS	ca$a	net/minecraft/class_4049$class_4050
 FIELD	ca$a	Lca$a;	a	field_19621
 FIELD	ca$a	Lca$a;	b	field_19622
 FIELD	ca$a	Ljava/util/Map;	c	field_19623
@@ -15207,7 +15207,7 @@ METHOD	ca$a	(Ljava/util/HashMap;)V	a	method_17874
 METHOD	ca$a	(Lcee;Laer;)Lcee;	b	method_17875
 METHOD	ca$a	(Ljava/lang/String;)Lca$a;	valueOf	valueOf
 METHOD	ca$a	()[Lca$a;	values	values
-CLASS	caa	net/minecraft/class_4050
+CLASS	caa	net/minecraft/class_4051
 FIELD	caa	Lcaa;	a	field_19627
 FIELD	caa	[Lcaa;	b	field_19628
 METHOD	caa	(Ljava/lang/String;)Lcaa;	valueOf	valueOf
@@ -15323,34 +15323,34 @@ METHOD	cak	(Lbzk;IIII)I	a	method_17876
 METHOD	cak	(Ljava/lang/String;)Lcak;	valueOf	valueOf
 METHOD	cak	()[Lcak;	values	values
 CLASS	cak$1	net/minecraft/class_84$1
-CLASS	cam	net/minecraft/class_4051
+CLASS	cam	net/minecraft/class_4052
 METHOD	cam	(Lbzk;)Lbzh;	a	method_17877
 METHOD	cam	(Lbzk;Lbzg;)Lbzf;	a	method_17878
 METHOD	cam	(Lbzk;Lbzg;II)I	a	method_17879
 METHOD	cam	(Lbzl;Lbzg;II)I	a	method_17880
-CLASS	can	net/minecraft/class_4052
+CLASS	can	net/minecraft/class_4053
 METHOD	can	(Lbzh;Lbzk;Lbzg;)Lbzf;	a	method_17881
 METHOD	can	(Lbzk;Lbzg;Lbzf;II)I	a	method_17882
 METHOD	can	(Lbzk;Lbzh;)Lbzh;	a	method_17883
 METHOD	can	(Lbzk;Lbzg;Lbzf;II)I	b	method_17884
-CLASS	cao	net/minecraft/class_4053
+CLASS	cao	net/minecraft/class_4054
 METHOD	cao	(Lbzh;Lbzh;Lbzk;Lbzg;)Lbzf;	a	method_17885
 METHOD	cao	(Lbzk;Lbzg;Lbzf;Lbzf;II)I	a	method_17886
 METHOD	cao	(Lbzk;Lbzh;Lbzh;)Lbzh;	a	method_17887
 METHOD	cao	(Lbzl;Lbzg;Lbzf;Lbzf;II)I	a	method_17888
-CLASS	cap	net/minecraft/class_4054
+CLASS	cap	net/minecraft/class_4055
 METHOD	cap	(Lbzl;IIIII)I	a	method_17889
-CLASS	caq	net/minecraft/class_4055
+CLASS	caq	net/minecraft/class_4056
 METHOD	caq	(Lbzl;I)I	a	method_17890
-CLASS	car	net/minecraft/class_4056
+CLASS	car	net/minecraft/class_4057
 METHOD	car	(Lbzl;I)I	a	method_17891
-CLASS	cas	net/minecraft/class_4057
+CLASS	cas	net/minecraft/class_4058
 METHOD	cas	(Lbzl;IIIII)I	a	method_17892
-CLASS	cat	net/minecraft/class_4058
-CLASS	cau	net/minecraft/class_4059
-CLASS	cav	net/minecraft/class_4060
+CLASS	cat	net/minecraft/class_4059
+CLASS	cau	net/minecraft/class_4060
+CLASS	cav	net/minecraft/class_4061
 METHOD	cav	(Lbzg;)Lbzg;	a	method_17893
-CLASS	caw	net/minecraft/class_4061
+CLASS	caw	net/minecraft/class_4062
 METHOD	caw	(II)I	apply	apply
 CLASS	caz	net/minecraft/class_2769
 FIELD	caz	[Lcbc;	a	field_13050
@@ -15362,7 +15362,7 @@ METHOD	caz	(Lcbc;F)V	a	method_11902
 METHOD	caz	(I)V	b	method_11903
 METHOD	caz	()Lcbc;	c	method_11904
 METHOD	caz	()Z	e	method_11905
-CLASS	cb	net/minecraft/class_4062
+CLASS	cb	net/minecraft/class_4063
 FIELD	cb	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_19704
 FIELD	cb	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_19705
 FIELD	cb	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_19706
@@ -15389,7 +15389,7 @@ METHOD	cb	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava
 METHOD	cb	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cb	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	cb	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cb$a	net/minecraft/class_4062$class_4063
+CLASS	cb$a	net/minecraft/class_4063$class_4064
 METHOD	cb$a	(Lcb;Lcom/google/gson/JsonObject;)V	a	method_17908
 METHOD	cb$a	(Lcb;Lhy;)V	a	method_17909
 METHOD	cb$a	(Lhy;)Lcb;	a	method_17910
@@ -15494,7 +15494,7 @@ METHOD	cbe	()Lcee;	f	method_11938
 METHOD	cbe	()[Lcbc;	g	method_13397
 METHOD	cbe	()[Lcbc;	h	method_13398
 METHOD	cbe	()Lcbc;	i	method_13399
-CLASS	cbf	net/minecraft/class_4064
+CLASS	cbf	net/minecraft/class_4065
 FIELD	cbf	Lcbf;	a	field_19715
 FIELD	cbf	Lcbf;	b	field_19716
 FIELD	cbf	Lcbf;	c	field_19717
@@ -15515,7 +15515,7 @@ CLASS	cbh	net/minecraft/class_2285
 FIELD	cbh	Z	j	field_19719
 METHOD	cbh	(III)Lcbc;	b	method_11944
 METHOD	cbh	(III)Lcba;	c	method_11945
-CLASS	cbi	net/minecraft/class_4065
+CLASS	cbi	net/minecraft/class_4066
 FIELD	cbi	F	k	field_19720
 FIELD	cbi	F	l	field_19721
 METHOD	cbi	(IIIID)Lcbc;	a	method_17911
@@ -15541,7 +15541,7 @@ METHOD	cbo	(Lgy;)Lgy;	b	method_191
 METHOD	cbo	()V	c	method_187
 METHOD	cbo	()Z	d	method_190
 METHOD	cbo	()Ljava/lang/String;	e	method_17914
-CLASS	cbp	net/minecraft/class_4066
+CLASS	cbp	net/minecraft/class_4067
 FIELD	cbp	Lel;	a	field_19722
 FIELD	cbp	Lasc;	b	field_19723
 FIELD	cbp	Lij;	c	field_19724
@@ -15555,7 +15555,7 @@ METHOD	cbp	()Lgy;	e	method_17921
 METHOD	cbp	(Ljava/lang/Object;)Z	equals	equals
 METHOD	cbp	()Ljava/lang/String;	f	method_17922
 METHOD	cbp	()I	hashCode	hashCode
-CLASS	cbp$1	net/minecraft/class_4066$1
+CLASS	cbp$1	net/minecraft/class_4067$1
 FIELD	cbp$1	[I	a	field_19725
 CLASS	cbq	net/minecraft/class_3082
 FIELD	cbq	Lcbq$a;	a	field_15220
@@ -15611,7 +15611,7 @@ METHOD	cbq$a	()Z	c	method_13828
 METHOD	cbq$a	()I	d	method_13829
 METHOD	cbq$a	(Ljava/lang/String;)Lcbq$a;	valueOf	valueOf
 METHOD	cbq$a	()[Lcbq$a;	values	values
-CLASS	cbr	net/minecraft/class_4067
+CLASS	cbr	net/minecraft/class_4068
 FIELD	cbr	Lel;	a	field_19744
 FIELD	cbr	I	b	field_19745
 FIELD	cbr	I	c	field_19746
@@ -15669,7 +15669,7 @@ METHOD	cbw	()I	c	method_195
 METHOD	cbw	(Ljava/lang/String;)V	i	method_196
 CLASS	cbx	net/minecraft/class_97
 FIELD	cbx	Lccb;	b	field_225
-CLASS	cby	net/minecraft/class_4068
+CLASS	cby	net/minecraft/class_4069
 FIELD	cby	Lorg/apache/logging/log4j/Logger;	a	field_19750
 FIELD	cby	Lbod;	b	field_19751
 FIELD	cby	Ljava/util/Map;	c	field_19752
@@ -15691,7 +15691,7 @@ FIELD	cbz	J	e	field_230
 FIELD	cbz	Ljava/lang/String;	f	field_231
 FIELD	cbz	Lbxm;	g	field_19756
 METHOD	cbz	()V	j	method_199
-CLASS	cc	net/minecraft/class_4069
+CLASS	cc	net/minecraft/class_4070
 FIELD	cc	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_19757
 FIELD	cc	Ljava/util/Collection;	b	field_19758
 METHOD	cc	()Lcc;	a	method_17944
@@ -15919,7 +15919,7 @@ METHOD	cci	(Laog;)V	a	method_264
 METHOD	cci	(Laog;)Lgy;	b	method_265
 METHOD	cci	()[Ljava/lang/String;	f	method_266
 CLASS	ccj	net/minecraft/class_2288
-CLASS	cck	net/minecraft/class_4070
+CLASS	cck	net/minecraft/class_4071
 FIELD	cck	Ljava/util/Map;	a	field_19776
 FIELD	cck	Lccc;	b	field_19777
 METHOD	cck	()V	a	method_17975
@@ -16167,7 +16167,7 @@ METHOD	ccw	(Lccw;)Z	b	method_12025
 CLASS	ccw$a	net/minecraft/class_2793$class_2794
 METHOD	ccw$a	(Lcom/google/gson/JsonObject;Lccw;Lcom/google/gson/JsonSerializationContext;)V	a	method_12026
 METHOD	ccw$a	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;[Lcdk;)Lccw;	a	method_12027
-CLASS	ccx	net/minecraft/class_4071
+CLASS	ccx	net/minecraft/class_4072
 FIELD	ccx	Lorg/apache/logging/log4j/Logger;	a	field_19799
 FIELD	ccx	Ljava/lang/String;	b	field_19800
 FIELD	ccx	Lcbq$a;	c	field_19801
@@ -16177,7 +16177,7 @@ FIELD	ccx	Z	f	field_19804
 METHOD	ccx	()Lorg/apache/logging/log4j/Logger;	a	method_17983
 METHOD	ccx	(Lccx;)Ljava/lang/String;	a	method_17984
 METHOD	ccx	(Lccx;)Lcbq$a;	b	method_17985
-CLASS	ccx$a	net/minecraft/class_4071$class_4072
+CLASS	ccx$a	net/minecraft/class_4072$class_4073
 METHOD	ccx$a	(Lcom/google/gson/JsonObject;Lccx;Lcom/google/gson/JsonSerializationContext;)V	a	method_17986
 METHOD	ccx$a	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;[Lcdk;)Lccx;	a	method_17987
 CLASS	ccy	net/minecraft/class_2795
@@ -16202,7 +16202,7 @@ METHOD	ccz$a	(Lccy;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationCon
 METHOD	ccz$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lccy;	a	method_12038
 METHOD	ccz$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
 METHOD	ccz$a	(Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;	serialize	serialize
-CLASS	cd	net/minecraft/class_4073
+CLASS	cd	net/minecraft/class_4074
 FIELD	cd	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_19805
 FIELD	cd	Ljava/util/Collection;	b	field_19806
 METHOD	cd	()Lcd;	a	method_17988
@@ -16213,9 +16213,9 @@ METHOD	cd	(Ljava/lang/String;Lbu;)Ljava/util/Collection;	a	method_17992
 METHOD	cd	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cd	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	cd	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cd$a	net/minecraft/class_4073$class_4074
+CLASS	cd$a	net/minecraft/class_4074$class_4075
 METHOD	cd$a	(Lbu;)Ljava/util/Collection;	getNames	getNames
-CLASS	cd$b	net/minecraft/class_4073$class_4075
+CLASS	cd$b	net/minecraft/class_4074$class_4076
 FIELD	cd$b	Ldr;	a	field_19807
 CLASS	cda	net/minecraft/class_2799
 FIELD	cda	Lccu;	a	field_13223
@@ -16262,10 +16262,10 @@ METHOD	cdd	(Lcdd;)Lccu;	a	method_12058
 CLASS	cdd$a	net/minecraft/class_2806$class_2807
 METHOD	cdd$a	(Lcom/google/gson/JsonObject;Lcdd;Lcom/google/gson/JsonSerializationContext;)V	a	method_12059
 METHOD	cdd$a	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;[Lcdk;)Lcdd;	a	method_12060
-CLASS	cde	net/minecraft/class_4076
+CLASS	cde	net/minecraft/class_4077
 FIELD	cde	Lij;	a	field_19808
 METHOD	cde	(Lcde;)Lij;	a	method_17993
-CLASS	cde$a	net/minecraft/class_4076$class_4077
+CLASS	cde$a	net/minecraft/class_4077$class_4078
 METHOD	cde$a	(Lcom/google/gson/JsonObject;Lcde;Lcom/google/gson/JsonSerializationContext;)V	a	method_17994
 METHOD	cde$a	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;[Lcdk;)Lcde;	a	method_17995
 CLASS	cdf	net/minecraft/class_2810
@@ -16373,7 +16373,7 @@ METHOD	cdw	()V	c	method_275
 METHOD	cdw	()V	run	run
 CLASS	cdx	net/minecraft/class_108
 METHOD	cdx	()Z	a	method_276
-CLASS	ce	net/minecraft/class_4078
+CLASS	ce	net/minecraft/class_4079
 FIELD	ce	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_19810
 FIELD	ce	Ljava/util/Collection;	b	field_19811
 METHOD	ce	()Lce;	a	method_17997
@@ -16434,7 +16434,7 @@ FIELD	ceb$a	Lceb$a;	c	field_603
 FIELD	ceb$a	[Lceb$a;	d	field_604
 METHOD	ceb$a	(Ljava/lang/String;)Lceb$a;	valueOf	valueOf
 METHOD	ceb$a	()[Lceb$a;	values	values
-CLASS	cec	net/minecraft/class_4079
+CLASS	cec	net/minecraft/class_4080
 FIELD	cec	Lcec;	a	field_19812
 FIELD	cec	Lcec;	b	field_19813
 FIELD	cec	Lcec;	c	field_19814
@@ -16483,13 +16483,13 @@ METHOD	cee	(Lcee;)D	f	method_618
 METHOD	cee	(Lcee;)D	g	method_620
 METHOD	cee	()I	hashCode	hashCode
 METHOD	cee	()Ljava/lang/String;	toString	toString
-CLASS	ceg	net/minecraft/class_4080
+CLASS	ceg	net/minecraft/class_4081
 FIELD	ceg	Lit/unimi/dsi/fastutil/doubles/DoubleList;	b	field_19817
 FIELD	ceg	Lit/unimi/dsi/fastutil/doubles/DoubleList;	c	field_19818
 FIELD	ceg	Lit/unimi/dsi/fastutil/doubles/DoubleList;	d	field_19819
-CLASS	ceg$1	net/minecraft/class_4080$1
+CLASS	ceg$1	net/minecraft/class_4081$1
 FIELD	ceg$1	[I	a	field_19820
-CLASS	ceh	net/minecraft/class_4081
+CLASS	ceh	net/minecraft/class_4082
 FIELD	ceh	Ljava/util/BitSet;	d	field_19821
 FIELD	ceh	I	e	field_19822
 FIELD	ceh	I	f	field_19823
@@ -16502,7 +16502,7 @@ METHOD	ceh	(Lcei;Lcem;IILcem;IILceh;II[I[ZIII)Z	a	method_18014
 METHOD	ceh	(Lcem;Lcem;Lceo;Lceo;Lceo;Lcei;)Lceh;	a	method_18015
 METHOD	ceh	(Lceo;Lcei;Lcem;ILcem;ILceh;I[I[ZIII)Z	a	method_18016
 METHOD	ceh	(Lceo;Lceo;Lcei;Lcem;Lcem;Lceh;[IIII)Z	a	method_18017
-CLASS	cei	net/minecraft/class_4082
+CLASS	cei	net/minecraft/class_4083
 FIELD	cei	Lcei;	AND	AND
 FIELD	cei	Lcei;	CAUSED_BY	CAUSED_BY
 FIELD	cei	Lcei;	CAUSES	CAUSES
@@ -16536,17 +16536,17 @@ METHOD	cei	(ZZ)Z	lambda$static$6	lambda$static$6
 METHOD	cei	(ZZ)Z	lambda$static$7	lambda$static$7
 METHOD	cei	(ZZ)Z	lambda$static$8	lambda$static$8
 METHOD	cei	(ZZ)Z	lambda$static$9	lambda$static$9
-CLASS	cej	net/minecraft/class_4083
+CLASS	cej	net/minecraft/class_4084
 FIELD	cej	I	a	field_19829
 METHOD	cej	(I)D	getDouble	getDouble
 METHOD	cej	()I	size	size
-CLASS	cek	net/minecraft/class_4084
-CLASS	cel	net/minecraft/class_4085
+CLASS	cek	net/minecraft/class_4085
+CLASS	cel	net/minecraft/class_4086
 FIELD	cel	Lcej;	a	field_19830
 FIELD	cel	I	b	field_19831
 FIELD	cel	I	c	field_19832
 FIELD	cel	I	d	field_19833
-CLASS	cem	net/minecraft/class_4086
+CLASS	cem	net/minecraft/class_4087
 FIELD	cem	I	a	field_19834
 FIELD	cem	I	b	field_19835
 FIELD	cem	I	c	field_19836
@@ -16573,27 +16573,27 @@ METHOD	cem	()I	c	method_18036
 METHOD	cem	(III)Z	c	method_18037
 METHOD	cem	(Leq$a;)I	c	method_18038
 METHOD	cem	()I	d	method_18039
-CLASS	cem$a	net/minecraft/class_4086$class_4087
+CLASS	cem$a	net/minecraft/class_4087$class_4088
 METHOD	cem$a	(Leq;III)V	consume	consume
-CLASS	cem$b	net/minecraft/class_4086$class_4088
+CLASS	cem$b	net/minecraft/class_4087$class_4089
 METHOD	cem$b	(IIIIII)V	consume	consume
-CLASS	cen	net/minecraft/class_4089
+CLASS	cen	net/minecraft/class_4090
 FIELD	cen	Lit/unimi/dsi/fastutil/doubles/DoubleList;	a	field_19838
-CLASS	ceo	net/minecraft/class_4090
+CLASS	ceo	net/minecraft/class_4091
 METHOD	ceo	()Lit/unimi/dsi/fastutil/doubles/DoubleList;	a	method_18040
 METHOD	ceo	(Lceo$a;)Z	a	method_18041
-CLASS	ceo$a	net/minecraft/class_4090$class_4091
+CLASS	ceo$a	net/minecraft/class_4091$class_4092
 METHOD	ceo$a	(III)Z	merge	merge
-CLASS	cep	net/minecraft/class_4092
+CLASS	cep	net/minecraft/class_4093
 FIELD	cep	Lit/unimi/dsi/fastutil/doubles/DoubleArrayList;	a	field_19839
 FIELD	cep	Lit/unimi/dsi/fastutil/ints/IntArrayList;	b	field_19840
 FIELD	cep	Lit/unimi/dsi/fastutil/ints/IntArrayList;	c	field_19841
-CLASS	ceq	net/minecraft/class_4093
+CLASS	ceq	net/minecraft/class_4094
 FIELD	ceq	I	a	field_19842
 FIELD	ceq	I	b	field_19843
 METHOD	ceq	(I)D	getDouble	getDouble
 METHOD	ceq	()I	size	size
-CLASS	cer	net/minecraft/class_4094
+CLASS	cer	net/minecraft/class_4095
 FIELD	cer	Lit/unimi/dsi/fastutil/doubles/DoubleList;	a	field_19844
 FIELD	cer	Lit/unimi/dsi/fastutil/doubles/DoubleList;	b	field_19845
 FIELD	cer	Z	c	field_19846
@@ -16601,12 +16601,12 @@ METHOD	cer	(Lceo$a;III)Z	a	method_18042
 METHOD	cer	(Lceo$a;)Z	b	method_18043
 METHOD	cer	(I)D	getDouble	getDouble
 METHOD	cer	()I	size	size
-CLASS	ces	net/minecraft/class_4095
+CLASS	ces	net/minecraft/class_4096
 FIELD	ces	Lit/unimi/dsi/fastutil/doubles/DoubleList;	a	field_19847
 FIELD	ces	D	b	field_19848
 METHOD	ces	(I)D	getDouble	getDouble
 METHOD	ces	()I	size	size
-CLASS	cet	net/minecraft/class_4096
+CLASS	cet	net/minecraft/class_4097
 FIELD	cet	Lcew;	a	field_19849
 FIELD	cet	Lcew;	b	field_19850
 METHOD	cet	()Lcew;	a	method_18044
@@ -16628,14 +16628,14 @@ METHOD	cet	(Lcew;Lcew;Lcei;)Lcew;	b	method_18059
 METHOD	cet	(Lcew;Lcew;Leq;)Z	b	method_18060
 METHOD	cet	()Lcek;	c	method_18061
 METHOD	cet	(Lcew;Lcew;Lcei;)Z	c	method_18062
-CLASS	cet$a	net/minecraft/class_4096$class_4097
+CLASS	cet$a	net/minecraft/class_4097$class_4098
 METHOD	cet$a	(DDDDDD)V	consume	consume
-CLASS	ceu	net/minecraft/class_4098
+CLASS	ceu	net/minecraft/class_4099
 FIELD	ceu	Lcew;	b	field_19851
 FIELD	ceu	Leq$a;	c	field_19852
 FIELD	ceu	Lit/unimi/dsi/fastutil/doubles/DoubleList;	d	field_19853
 METHOD	ceu	(Lcem;Leq$a;I)Lcem;	a	method_18063
-CLASS	cev	net/minecraft/class_4099
+CLASS	cev	net/minecraft/class_4100
 FIELD	cev	Lcem;	d	field_19854
 FIELD	cev	I	e	field_19855
 FIELD	cev	I	f	field_19856
@@ -16643,7 +16643,7 @@ FIELD	cev	I	g	field_19857
 FIELD	cev	I	h	field_19858
 FIELD	cev	I	i	field_19859
 FIELD	cev	I	j	field_19860
-CLASS	cew	net/minecraft/class_4100
+CLASS	cew	net/minecraft/class_4101
 FIELD	cew	Lcem;	a	field_19861
 METHOD	cew	()Lcea;	a	method_18064
 METHOD	cew	(DDD)Lcew;	a	method_18065
@@ -16670,7 +16670,7 @@ METHOD	cew	()Lcew;	c	method_18085
 METHOD	cew	(Leq$a;)D	c	method_18086
 METHOD	cew	()Ljava/util/List;	d	method_18087
 METHOD	cew	()Ljava/lang/String;	toString	toString
-CLASS	cex	net/minecraft/class_4101
+CLASS	cex	net/minecraft/class_4102
 FIELD	cex	I	b	field_19862
 FIELD	cex	I	c	field_19863
 FIELD	cex	I	d	field_19864
@@ -16689,19 +16689,19 @@ METHOD	cez	()Lcff;	c	method_4848
 METHOD	cez	()Lij;	d	method_4849
 METHOD	cez	()Lij;	e	method_18090
 METHOD	cez	()Lcff$a;	f	method_9351
-CLASS	cf	net/minecraft/class_4102
+CLASS	cf	net/minecraft/class_4103
 FIELD	cf	Ljava/util/Collection;	a	field_19867
 METHOD	cf	()Lcf;	a	method_18091
 METHOD	cf	(Lcom/mojang/brigadier/StringReader;)Lcf$a;	a	method_18092
 METHOD	cf	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lij;	a	method_18093
 METHOD	cf	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cf	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cf$a	net/minecraft/class_4102$class_4103
+CLASS	cf$a	net/minecraft/class_4103$class_4104
 FIELD	cf$a	Ljava/lang/String;	a	field_19868
 FIELD	cf$a	[Lcf$b;	b	field_19869
 METHOD	cf$a	(Lbu;Z)Lij;	a	method_18094
 METHOD	cf$a	(Lcom/mojang/brigadier/StringReader;Z)Lcf$a;	a	method_18095
-CLASS	cf$b	net/minecraft/class_4102$class_2306
+CLASS	cf$b	net/minecraft/class_4103$class_2306
 FIELD	cf$b	I	a	field_10393
 FIELD	cf$b	I	b	field_19870
 FIELD	cf$b	Ldr;	c	field_19871
@@ -16888,7 +16888,7 @@ METHOD	cff	(Lwr;Lpc;)Lcff;	a	method_18130
 METHOD	cff	()Ljava/lang/String;	c	method_4917
 METHOD	cff	()Z	d	method_4919
 METHOD	cff	()Lcff$a;	e	method_18131
-CLASS	cff$a	net/minecraft/class_1473$class_4104
+CLASS	cff$a	net/minecraft/class_1473$class_4105
 FIELD	cff$a	Lcff$a;	a	field_19896
 FIELD	cff$a	Lcff$a;	b	field_19897
 FIELD	cff$a	Ljava/lang/String;	c	field_19898
@@ -16928,12 +16928,12 @@ METHOD	cfj	()V	e	method_18142
 METHOD	cfj	(Lcfx;)Ljava/util/List;	e	method_18143
 METHOD	cfj	()Ljava/util/List;	f	method_18144
 METHOD	cfj	(Lavk;)Lcfx;	g	method_18145
-CLASS	cfk	net/minecraft/class_4105
+CLASS	cfk	net/minecraft/class_4106
 FIELD	cfk	Ljava/lang/invoke/MethodHandle;	a	field_19904
 METHOD	cfk	()Ljava/lang/invoke/MethodHandle;	a	method_18146
 METHOD	cfk	(J)V	a	method_18147
 METHOD	cfk	(Lorg/lwjgl/system/Pointer;)V	a	method_18148
-CLASS	cfl	net/minecraft/class_4106
+CLASS	cfl	net/minecraft/class_4107
 FIELD	cfl	Lcrd;	a	field_19905
 FIELD	cfl	I	b	field_19906
 FIELD	cfl	Ljava/util/function/Consumer;	c	field_19907
@@ -16957,14 +16957,14 @@ FIELD	cfn	Z	e	field_19909
 METHOD	cfn	()V	a	method_14451
 METHOD	cfn	(I)Lctl;	a	method_14450
 METHOD	cfn	()V	b	method_18153
-CLASS	cfo	net/minecraft/class_4107
+CLASS	cfo	net/minecraft/class_4108
 FIELD	cfo	Lcfo$a;	a	field_19910
 METHOD	cfo	(I)Z	a	method_18154
 METHOD	cfo	(II)Lcfo$a;	a	method_18155
 METHOD	cfo	(Ljava/lang/String;)Lcfo$a;	a	method_18156
-CLASS	cfo$1	net/minecraft/class_4107$1
+CLASS	cfo$1	net/minecraft/class_4108$1
 FIELD	cfo$1	[I	a	field_19911
-CLASS	cfo$a	net/minecraft/class_4107$class_4108
+CLASS	cfo$a	net/minecraft/class_4108$class_4109
 FIELD	cfo$a	Ljava/lang/String;	a	field_19912
 FIELD	cfo$a	Lcfo$b;	b	field_19913
 FIELD	cfo$a	I	c	field_19914
@@ -16977,7 +16977,7 @@ METHOD	cfo$a	()Ljava/util/Map;	e	method_18161
 METHOD	cfo$a	(Ljava/lang/Object;)Z	equals	equals
 METHOD	cfo$a	()I	hashCode	hashCode
 METHOD	cfo$a	()Ljava/lang/String;	toString	toString
-CLASS	cfo$b	net/minecraft/class_4107$class_4109
+CLASS	cfo$b	net/minecraft/class_4108$class_4110
 FIELD	cfo$b	Lcfo$b;	a	field_19916
 FIELD	cfo$b	Lcfo$b;	b	field_19917
 FIELD	cfo$b	Lcfo$b;	c	field_19918
@@ -17025,7 +17025,7 @@ METHOD	cfp	()Ljava/lang/String;	j	method_18174
 METHOD	cfp	()Z	k	method_18175
 METHOD	cfp	()Ljava/lang/String;	l	method_18176
 METHOD	cfp	()V	m	method_842
-CLASS	cfq	net/minecraft/class_4110
+CLASS	cfq	net/minecraft/class_4111
 FIELD	cfq	Lcft;	a	field_19926
 FIELD	cfq	Z	b	field_19927
 FIELD	cfq	J	c	field_19928
@@ -17055,7 +17055,7 @@ METHOD	cfq	(Lij;)V	b	method_18195
 METHOD	cfq	(Ljava/lang/String;[Ljava/lang/Object;)V	b	method_18196
 METHOD	cfq	(Lpc;Lcee;Lgy;)V	b	method_18197
 METHOD	cfq	(I)Z	c	method_18198
-CLASS	cfq$1	net/minecraft/class_4110$1
+CLASS	cfq$1	net/minecraft/class_4111$1
 FIELD	cfq$1	[I	a	field_19933
 CLASS	cfr	net/minecraft/class_328
 FIELD	cfr	Ljava/nio/FloatBuffer;	a	field_910
@@ -17290,7 +17290,7 @@ METHOD	cft$1	()V	run	run
 CLASS	cft$2	net/minecraft/class_1600$2
 FIELD	cft$2	[I	a	field_19947
 FIELD	cft$2	[I	b	field_19948
-CLASS	cfu	net/minecraft/class_4111
+CLASS	cfu	net/minecraft/class_4112
 FIELD	cfu	Lcgc;	a	field_19949
 FIELD	cfu	J	b	field_19950
 FIELD	cfu	Ljava/util/List;	c	field_19951
@@ -17307,7 +17307,7 @@ METHOD	cfu	()I	d	method_18236
 METHOD	cfu	()I	e	method_18237
 METHOD	cfu	()J	f	method_18238
 METHOD	cfu	()Ljava/lang/String;	toString	toString
-CLASS	cfv	net/minecraft/class_4112
+CLASS	cfv	net/minecraft/class_4113
 FIELD	cfv	Lcft;	a	field_19955
 FIELD	cfv	Z	b	field_19956
 FIELD	cfv	Z	c	field_19957
@@ -17539,7 +17539,7 @@ METHOD	cfw$a	()D	e	method_12152
 METHOD	cfw$a	()D	f	method_18267
 METHOD	cfw$a	(Ljava/lang/String;)Lcfw$a;	valueOf	valueOf
 METHOD	cfw$a	()[Lcfw$a;	values	values
-CLASS	cfx	net/minecraft/class_4113
+CLASS	cfx	net/minecraft/class_4114
 FIELD	cfx	Lcfx;	a	field_20000
 FIELD	cfx	Lcfx;	b	field_20001
 FIELD	cfx	Lcfx;	c	field_20002
@@ -17570,7 +17570,7 @@ FIELD	cfz	F	c	field_1040
 FIELD	cfz	J	d	field_1042
 FIELD	cfz	F	e	field_15885
 METHOD	cfz	(J)V	a	method_18274
-CLASS	cg	net/minecraft/class_4114
+CLASS	cg	net/minecraft/class_4115
 FIELD	cg	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_20011
 FIELD	cg	Ljava/util/Collection;	b	field_20012
 METHOD	cg	()Lcg;	a	method_18275
@@ -17600,7 +17600,7 @@ METHOD	cga$a	(Lcga$a;)Ljava/lang/String;	a	method_18279
 METHOD	cga$a	(Ljava/lang/String;)Lcga$a;	a	method_6671
 METHOD	cga$a	(Ljava/lang/String;)Lcga$a;	valueOf	valueOf
 METHOD	cga$a	()[Lcga$a;	values	values
-CLASS	cgb	net/minecraft/class_4115
+CLASS	cgb	net/minecraft/class_4116
 FIELD	cgb	I	a	field_20015
 FIELD	cgb	I	b	field_20016
 FIELD	cgb	I	c	field_20017
@@ -17619,7 +17619,7 @@ METHOD	cgb	()I	f	method_18286
 METHOD	cgb	()Ljava/lang/String;	g	method_18287
 METHOD	cgb	()I	hashCode	hashCode
 METHOD	cgb	()Ljava/lang/String;	toString	toString
-CLASS	cgc	net/minecraft/class_4116
+CLASS	cgc	net/minecraft/class_4117
 FIELD	cgc	Lcft;	a	field_20022
 FIELD	cgc	Ljava/util/Map;	b	field_20023
 FIELD	cgc	Ljava/util/Map;	c	field_20024
@@ -17629,7 +17629,7 @@ METHOD	cgc	(JI)V	a	method_18289
 METHOD	cgc	(Lcgd;)Lcfu;	a	method_18290
 METHOD	cgc	(Lcnq$a;Ljava/lang/String;)Lcgd;	a	method_18291
 METHOD	cgc	()V	close	close
-CLASS	cgd	net/minecraft/class_4117
+CLASS	cgd	net/minecraft/class_4118
 FIELD	cgd	Lorg/apache/logging/log4j/Logger;	a	field_20026
 FIELD	cgd	Lorg/lwjgl/glfw/GLFWErrorCallback;	b	field_20027
 FIELD	cgd	Lcft;	c	field_20028
@@ -17759,7 +17759,7 @@ METHOD	cgk	()V	close	close
 METHOD	cgk	(Ljava/lang/String;I)Ljava/lang/String;	d	method_974
 METHOD	cgk	(Ljava/lang/String;I)I	e	method_976
 CLASS	cgk$1	net/minecraft/class_370$1
-CLASS	cgk$a	net/minecraft/class_370$class_4118
+CLASS	cgk$a	net/minecraft/class_370$class_4119
 FIELD	cgk$a	F	a	field_20053
 FIELD	cgk$a	F	b	field_20054
 FIELD	cgk$a	F	c	field_20055
@@ -18036,7 +18036,7 @@ METHOD	cgy	()Z	m	method_944
 METHOD	cgy	()I	o	method_945
 METHOD	cgy	()I	p	method_946
 METHOD	cgy	()Z	r	method_947
-CLASS	ch	net/minecraft/class_4119
+CLASS	ch	net/minecraft/class_4120
 FIELD	ch	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_20071
 FIELD	ch	Ljava/util/Collection;	b	field_20072
 METHOD	ch	()Lch;	a	method_18393
@@ -18108,7 +18108,7 @@ METHOD	chg$a	(IIIIZF)V	a	method_6700
 METHOD	chg$a	()I	b	method_18402
 METHOD	chg$a	()I	c	method_18403
 METHOD	chg$a	()I	d	method_18404
-CLASS	chg$b	net/minecraft/class_1802$class_4120
+CLASS	chg$b	net/minecraft/class_1802$class_4121
 FIELD	chg$b	Lchg;	a	field_20076
 FIELD	chg$b	Ljava/util/List;	b	field_20077
 METHOD	chg$b	(I)Lchg$a;	a	method_18405
@@ -18233,7 +18233,7 @@ METHOD	cho$a	()Ljava/lang/String;	a	method_12177
 METHOD	cho$a	(Lcee;)V	a	method_12178
 METHOD	cho$a	()J	b	method_12179
 METHOD	cho$a	()Lcee;	c	method_12180
-CLASS	chq	net/minecraft/class_4121
+CLASS	chq	net/minecraft/class_4122
 FIELD	chq	Lchr;	a	field_20087
 FIELD	chq	Z	f	field_20088
 METHOD	chq	()Z	a	method_18419
@@ -18244,7 +18244,7 @@ METHOD	chq	()Ljava/util/List;	b	method_18423
 METHOD	chq	(Lchr;)V	b	method_18424
 METHOD	chq	(Z)V	e	method_18425
 METHOD	chq	()V	t	method_18426
-CLASS	chr	net/minecraft/class_4122
+CLASS	chr	net/minecraft/class_4123
 METHOD	chr	()Z	af_	method_18427
 METHOD	chr	(Z)V	b	method_18428
 METHOD	chr	(CI)Z	charTyped	charTyped
@@ -18254,7 +18254,7 @@ METHOD	chr	(DDI)Z	mouseClicked	mouseClicked
 METHOD	chr	(DDIDD)Z	mouseDragged	mouseDragged
 METHOD	chr	(DDI)Z	mouseReleased	mouseReleased
 METHOD	chr	(D)Z	mouseScrolled	mouseScrolled
-CLASS	chs	net/minecraft/class_4123
+CLASS	chs	net/minecraft/class_4124
 METHOD	chs	()Lchr;	getFocused	getFocused
 CLASS	chv	net/minecraft/class_2310
 FIELD	chv	Lpc;	a	field_10409
@@ -18296,7 +18296,7 @@ FIELD	chz$a	Lchz$a;	c	field_20089
 FIELD	chz$a	[Lchz$a;	d	field_15913
 METHOD	chz$a	(Ljava/lang/String;)Lchz$a;	valueOf	valueOf
 METHOD	chz$a	()[Lchz$a;	values	values
-CLASS	ci	net/minecraft/class_4124
+CLASS	ci	net/minecraft/class_4125
 FIELD	ci	Ljava/util/Collection;	a	field_20090
 FIELD	ci	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_20091
 FIELD	ci	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_20092
@@ -18312,11 +18312,11 @@ METHOD	ci	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	b	method_18439
 METHOD	ci	()Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	method_18440
 METHOD	ci	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	ci	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	ci$a	net/minecraft/class_4124$class_4125
+CLASS	ci$a	net/minecraft/class_4125$class_4126
 FIELD	ci$a	Ljava/lang/String;	a	field_20094
-CLASS	ci$b	net/minecraft/class_4124$class_4126
+CLASS	ci$b	net/minecraft/class_4125$class_4127
 FIELD	ci$b	I	a	field_20095
-CLASS	ci$c	net/minecraft/class_4124$class_4127
+CLASS	ci$c	net/minecraft/class_4125$class_4128
 FIELD	ci$c	Ljava/lang/String;	a	field_20096
 FIELD	ci$c	[Lci$d;	b	field_20097
 METHOD	ci$c	(I)Lho;	a	method_18441
@@ -18324,7 +18324,7 @@ METHOD	ci$c	(Lho;)Lho;	a	method_18442
 METHOD	ci$c	(Lho;Lho;)Lho;	a	method_18443
 METHOD	ci$c	(Lho;)V	b	method_18444
 METHOD	ci$c	()Ljava/lang/String;	toString	toString
-CLASS	ci$d	net/minecraft/class_4124$class_4128
+CLASS	ci$d	net/minecraft/class_4125$class_4129
 METHOD	ci$d	()Lho;	a	method_18445
 METHOD	ci$d	(Lho;)Lho;	a	method_18446
 METHOD	ci$d	(Lho;Lho;)V	a	method_18447
@@ -18386,8 +18386,8 @@ FIELD	cic$a	[Lcic$a;	h	field_15943
 METHOD	cic$a	(Lcgm;II)V	a	method_14500
 METHOD	cic$a	(Ljava/lang/String;)Lcic$a;	valueOf	valueOf
 METHOD	cic$a	()[Lcic$a;	values	values
-CLASS	cie	net/minecraft/class_4129
-CLASS	cif	net/minecraft/class_4130
+CLASS	cie	net/minecraft/class_4130
+CLASS	cif	net/minecraft/class_4131
 FIELD	cif	Lorg/apache/logging/log4j/Logger;	a	field_20098
 FIELD	cif	Ljava/util/Map;	b	field_20099
 FIELD	cif	Lddn;	c	field_20100
@@ -18399,7 +18399,7 @@ METHOD	cif	(Z)V	a	method_18454
 METHOD	cif	(Lpc;)Lcgk;	b	method_18455
 METHOD	cif	(Lpc;)Lcgk;	c	method_18456
 METHOD	cif	(Lpc;)Ljava/util/List;	d	method_18457
-CLASS	cig	net/minecraft/class_4131
+CLASS	cig	net/minecraft/class_4132
 FIELD	cig	Lorg/apache/logging/log4j/Logger;	a	field_20102
 FIELD	cig	Lcil;	b	field_20103
 FIELD	cig	Lcii;	c	field_20104
@@ -18424,15 +18424,15 @@ METHOD	cig	(I)Lcii;	b	method_18466
 METHOD	cig	(C)Lcij;	c	method_18467
 METHOD	cig	(I)Lit/unimi/dsi/fastutil/chars/CharList;	c	method_18468
 METHOD	cig	()V	close	close
-CLASS	cih	net/minecraft/class_4132
+CLASS	cih	net/minecraft/class_4133
 FIELD	cih	Lpc;	f	field_20114
 FIELD	cih	Z	g	field_20115
 FIELD	cih	Lcih$a;	h	field_20116
 METHOD	cih	()Lpc;	a	method_18469
 METHOD	cih	(Lcij;)Lcik;	a	method_18470
 METHOD	cih	()V	close	close
-CLASS	cih$1	net/minecraft/class_4132$1
-CLASS	cih$a	net/minecraft/class_4132$class_4133
+CLASS	cih$1	net/minecraft/class_4133$1
+CLASS	cih$a	net/minecraft/class_4133$class_4134
 FIELD	cih$a	I	a	field_20117
 FIELD	cih$a	I	b	field_20118
 FIELD	cih$a	I	c	field_20119
@@ -18441,13 +18441,13 @@ FIELD	cih$a	Lcih$a;	e	field_20121
 FIELD	cih$a	Lcih$a;	f	field_20122
 FIELD	cih$a	Z	g	field_20123
 METHOD	cih$a	(Lcij;)Lcih$a;	a	method_18471
-CLASS	cii	net/minecraft/class_4134
+CLASS	cii	net/minecraft/class_4135
 METHOD	cii	()F	getAdvance	getAdvance
 METHOD	cii	(Z)F	getAdvance	getAdvance
 METHOD	cii	()F	getBearingX	getBearingX
 METHOD	cii	()F	getBoldOffset	getBoldOffset
 METHOD	cii	()F	getShadowOffset	getShadowOffset
-CLASS	cij	net/minecraft/class_4135
+CLASS	cij	net/minecraft/class_4136
 METHOD	cij	()I	a	method_18472
 METHOD	cij	(II)V	a	method_18473
 METHOD	cij	()I	b	method_18474
@@ -18458,7 +18458,7 @@ METHOD	cij	()F	f	method_18478
 METHOD	cij	()F	g	method_18479
 METHOD	cij	()F	getBearingY	getBearingY
 METHOD	cij	()F	h	method_18480
-CLASS	cik	net/minecraft/class_4136
+CLASS	cik	net/minecraft/class_4137
 FIELD	cik	Lpc;	a	field_20124
 FIELD	cik	F	b	field_20125
 FIELD	cik	F	c	field_20126
@@ -18470,27 +18470,27 @@ FIELD	cik	F	h	field_20131
 FIELD	cik	F	i	field_20132
 METHOD	cik	()Lpc;	a	method_18481
 METHOD	cik	(Lddn;ZFFLctq;FFFF)V	a	method_18482
-CLASS	cil	net/minecraft/class_4137
-CLASS	cim	net/minecraft/class_4138
+CLASS	cil	net/minecraft/class_4138
+CLASS	cim	net/minecraft/class_4139
 FIELD	cim	Lcim;	a	field_20133
 FIELD	cim	Lddg;	b	field_20134
 FIELD	cim	[Lcim;	c	field_20135
 METHOD	cim	(Lddg;)V	a	method_18483
 METHOD	cim	(Ljava/lang/String;)Lcim;	valueOf	valueOf
 METHOD	cim	()[Lcim;	values	values
-CLASS	cip	net/minecraft/class_4139
+CLASS	cip	net/minecraft/class_4140
 FIELD	cip	Lorg/apache/logging/log4j/Logger;	a	field_20136
 FIELD	cip	Lddg;	b	field_20137
 FIELD	cip	Lit/unimi/dsi/fastutil/chars/Char2ObjectMap;	c	field_20138
-CLASS	cip$1	net/minecraft/class_4139$1
-CLASS	cip$a	net/minecraft/class_4139$class_4140
+CLASS	cip$1	net/minecraft/class_4140$1
+CLASS	cip$a	net/minecraft/class_4140$class_4141
 FIELD	cip$a	Lpc;	a	field_20139
 FIELD	cip$a	Ljava/util/List;	b	field_20140
 FIELD	cip$a	I	c	field_20141
 FIELD	cip$a	I	d	field_20142
 METHOD	cip$a	(Lcom/google/gson/JsonObject;)Lcip$a;	a	method_18484
 METHOD	cip$a	(Lddg;IIII)I	a	method_18485
-CLASS	cip$b	net/minecraft/class_4139$class_4141
+CLASS	cip$b	net/minecraft/class_4140$class_4142
 FIELD	cip$b	F	a	field_20143
 FIELD	cip$b	Lddg;	b	field_20144
 FIELD	cip$b	I	c	field_20145
@@ -18499,12 +18499,12 @@ FIELD	cip$b	I	e	field_20147
 FIELD	cip$b	I	f	field_20148
 FIELD	cip$b	I	g	field_20149
 FIELD	cip$b	I	h	field_20150
-CLASS	ciq	net/minecraft/class_4142
+CLASS	ciq	net/minecraft/class_4143
 METHOD	ciq	(C)Lcij;	a	method_18486
 METHOD	ciq	()V	close	close
-CLASS	cir	net/minecraft/class_4143
+CLASS	cir	net/minecraft/class_4144
 METHOD	cir	(Lvf;)Lciq;	a	method_18487
-CLASS	cis	net/minecraft/class_4144
+CLASS	cis	net/minecraft/class_4145
 FIELD	cis	Lcis;	a	field_20151
 FIELD	cis	Lcis;	b	field_20152
 FIELD	cis	Lcis;	c	field_20153
@@ -18517,7 +18517,7 @@ METHOD	cis	(Ljava/lang/String;)Lcis;	a	method_18489
 METHOD	cis	(Ljava/util/HashMap;)V	a	method_18490
 METHOD	cis	(Ljava/lang/String;)Lcis;	valueOf	valueOf
 METHOD	cis	()[Lcis;	values	values
-CLASS	cit	net/minecraft/class_4145
+CLASS	cit	net/minecraft/class_4146
 FIELD	cit	Lorg/apache/logging/log4j/Logger;	a	field_20158
 FIELD	cit	Lvf;	b	field_20159
 FIELD	cit	[B	c	field_20160
@@ -18528,18 +18528,18 @@ METHOD	cit	(B)I	a	method_18492
 METHOD	cit	(Lpc;)Lddg;	a	method_18493
 METHOD	cit	(B)I	b	method_18494
 METHOD	cit	(C)Lpc;	b	method_18495
-CLASS	cit$1	net/minecraft/class_4145$1
-CLASS	cit$a	net/minecraft/class_4145$class_4146
+CLASS	cit$1	net/minecraft/class_4146$1
+CLASS	cit$a	net/minecraft/class_4146$class_4147
 FIELD	cit$a	Lpc;	a	field_20163
 FIELD	cit$a	Ljava/lang/String;	b	field_20164
 METHOD	cit$a	(Lcom/google/gson/JsonObject;)Lcir;	a	method_18496
-CLASS	cit$b	net/minecraft/class_4145$class_4147
+CLASS	cit$b	net/minecraft/class_4146$class_4148
 FIELD	cit$b	I	a	field_20165
 FIELD	cit$b	I	b	field_20166
 FIELD	cit$b	I	c	field_20167
 FIELD	cit$b	I	d	field_20168
 FIELD	cit$b	Lddg;	e	field_20169
-CLASS	ciu	net/minecraft/class_4148
+CLASS	ciu	net/minecraft/class_4149
 FIELD	ciu	Lorg/apache/logging/log4j/Logger;	a	field_20170
 FIELD	ciu	Lorg/lwjgl/stb/STBTTFontinfo;	b	field_20171
 FIELD	ciu	F	c	field_20172
@@ -18557,8 +18557,8 @@ METHOD	ciu	(Lciu;)F	c	method_18502
 METHOD	ciu	(Lciu;)F	d	method_18503
 METHOD	ciu	(Lciu;)Lorg/lwjgl/stb/STBTTFontinfo;	e	method_18504
 METHOD	ciu	(Lciu;)F	f	method_18505
-CLASS	ciu$1	net/minecraft/class_4148$1
-CLASS	ciu$a	net/minecraft/class_4148$class_4149
+CLASS	ciu$1	net/minecraft/class_4149$1
+CLASS	ciu$a	net/minecraft/class_4149$class_4150
 FIELD	ciu$a	Lpc;	a	field_20178
 FIELD	ciu$a	F	b	field_20179
 FIELD	ciu$a	F	c	field_20180
@@ -18566,7 +18566,7 @@ FIELD	ciu$a	F	d	field_20181
 FIELD	ciu$a	F	e	field_20182
 FIELD	ciu$a	Ljava/lang/String;	f	field_20183
 METHOD	ciu$a	(Lcom/google/gson/JsonObject;)Lcir;	a	method_18506
-CLASS	ciu$b	net/minecraft/class_4148$class_4150
+CLASS	ciu$b	net/minecraft/class_4149$class_4151
 FIELD	ciu$b	Lciu;	a	field_20184
 FIELD	ciu$b	I	b	field_20185
 FIELD	ciu$b	I	c	field_20186
@@ -18614,7 +18614,7 @@ METHOD	ciz	()I	i	method_6732
 METHOD	ciz	()V	j	method_18518
 METHOD	ciz	()Ljava/util/List;	k	method_6734
 METHOD	ciz	()V	m	method_18519
-CLASS	cj	net/minecraft/class_4151
+CLASS	cj	net/minecraft/class_4152
 FIELD	cj	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_20192
 FIELD	cj	Ljava/util/Collection;	b	field_20193
 FIELD	cj	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_20194
@@ -18635,7 +18635,7 @@ METHOD	cja	()I	c	method_6735
 CLASS	cjb	net/minecraft/class_2312
 FIELD	cjb	Lnet/minecraft/realms/RealmsSimpleScrolledSelectionList;	v	field_10415
 METHOD	cjb	()I	c	method_9545
-CLASS	cjd	net/minecraft/class_4152
+CLASS	cjd	net/minecraft/class_4153
 FIELD	cjd	Lij;	a	field_20196
 FIELD	cjd	Lij;	f	field_20197
 FIELD	cjd	Ljava/lang/String;	g	field_20198
@@ -18643,9 +18643,9 @@ FIELD	cjd	Ljava/lang/Runnable;	h	field_20199
 FIELD	cjd	Ljava/util/List;	i	field_20200
 FIELD	cjd	I	s	field_20201
 METHOD	cjd	(Lcjd;)Ljava/lang/Runnable;	a	method_18527
-CLASS	cjd$1	net/minecraft/class_4152$1
+CLASS	cjd$1	net/minecraft/class_4153$1
 FIELD	cjd$1	Lcjd;	o	field_20202
-CLASS	cje	net/minecraft/class_4153
+CLASS	cje	net/minecraft/class_4154
 FIELD	cje	Lcje$a;	a	field_20203
 FIELD	cje	Ljava/lang/String;	f	field_20204
 FIELD	cje	Ljava/lang/String;	g	field_20205
@@ -18655,13 +18655,13 @@ FIELD	cje	Lckd;	s	field_20208
 FIELD	cje	Ljava/lang/String;	t	field_20209
 FIELD	cje	Ljava/util/List;	u	field_20210
 METHOD	cje	(Lcje;)Lckd;	a	method_18528
-CLASS	cje$1	net/minecraft/class_4153$1
+CLASS	cje$1	net/minecraft/class_4154$1
 FIELD	cje$1	Lcje;	o	field_20211
-CLASS	cje$2	net/minecraft/class_4153$2
+CLASS	cje$2	net/minecraft/class_4154$2
 FIELD	cje$2	Lcje;	o	field_20212
-CLASS	cje$3	net/minecraft/class_4153$3
+CLASS	cje$3	net/minecraft/class_4154$3
 FIELD	cje$3	Lcje;	o	field_20213
-CLASS	cje$a	net/minecraft/class_4153$class_4154
+CLASS	cje$a	net/minecraft/class_4154$class_4155
 METHOD	cje$a	(Z)V	proceed	proceed
 CLASS	cjf	net/minecraft/class_358
 FIELD	cjf	[Lcfw$a;	a	field_1062
@@ -18707,7 +18707,7 @@ METHOD	cjg	()V	i	method_18543
 METHOD	cjg	()V	j	method_18544
 METHOD	cjg	()V	k	method_18545
 CLASS	cjg$1	net/minecraft/class_359$1
-CLASS	cjg$a	net/minecraft/class_359$class_4155
+CLASS	cjg$a	net/minecraft/class_359$class_4156
 FIELD	cjg$a	Lcjg;	a	field_20225
 FIELD	cjg$a	Lcuj;	b	field_20226
 FIELD	cjg$a	Lcom/mojang/brigadier/suggestion/Suggestions;	c	field_20227
@@ -18779,7 +18779,7 @@ METHOD	cjk$1	(Ljava/lang/String;)V	a	method_18559
 METHOD	cjk$1	()V	run	run
 CLASS	cjk$2	net/minecraft/class_472$2
 FIELD	cjk$2	Lcjk;	o	field_20242
-CLASS	cjl	net/minecraft/class_4156
+CLASS	cjl	net/minecraft/class_4157
 FIELD	cjl	Ljava/util/List;	a	field_20243
 FIELD	cjl	Lcmy;	f	field_20244
 FIELD	cjl	Ljava/util/List;	g	field_20245
@@ -18801,13 +18801,13 @@ METHOD	cjl	(Lcjl;)Ljava/util/List;	f	method_18569
 METHOD	cjl	()V	h	method_18570
 METHOD	cjl	()Ljava/util/List;	i	method_18571
 METHOD	cjl	()Lgy;	j	method_18572
-CLASS	cjl$1	net/minecraft/class_4156$1
+CLASS	cjl$1	net/minecraft/class_4157$1
 FIELD	cjl$1	Lcjl;	o	field_20251
-CLASS	cjl$2	net/minecraft/class_4156$2
+CLASS	cjl$2	net/minecraft/class_4157$2
 FIELD	cjl$2	Lcjl;	o	field_20252
-CLASS	cjl$3	net/minecraft/class_4156$3
+CLASS	cjl$3	net/minecraft/class_4157$3
 FIELD	cjl$3	Lcjl;	o	field_20253
-CLASS	cjl$a	net/minecraft/class_4156$class_2316
+CLASS	cjl$a	net/minecraft/class_4157$class_2316
 FIELD	cjl$a	Lcjl;	v	field_10431
 CLASS	cjm	net/minecraft/class_1318
 FIELD	cjm	Lcmy;	a	field_5061
@@ -18915,7 +18915,7 @@ FIELD	cjs	Ljava/lang/String;	a	field_1138
 FIELD	cjs	Ljava/lang/String;	f	field_1139
 CLASS	cjs$1	net/minecraft/class_369$1
 FIELD	cjs$1	Lcjs;	o	field_20274
-CLASS	cjt	net/minecraft/class_4157
+CLASS	cjt	net/minecraft/class_4158
 FIELD	cjt	Ljava/lang/String;	a	field_20275
 CLASS	cju	net/minecraft/class_374
 METHOD	cju	(Lcju;)V	a	method_18592
@@ -18943,7 +18943,7 @@ CLASS	cjv$a	net/minecraft/class_380$class_381
 FIELD	cjv$a	Lcjv;	v	field_1208
 FIELD	cjv$a	Ljava/util/List;	w	field_6294
 FIELD	cjv$a	Ljava/util/Map;	x	field_6295
-CLASS	cjw	net/minecraft/class_4158
+CLASS	cjw	net/minecraft/class_4159
 FIELD	cjw	Lorg/apache/logging/log4j/Logger;	a	field_20279
 FIELD	cjw	Lpc;	f	field_20280
 FIELD	cjw	Lpc;	g	field_20281
@@ -19002,7 +19002,7 @@ CLASS	cjz$5	net/minecraft/class_385$5
 FIELD	cjz$5	Lcjz;	o	field_20301
 CLASS	cjz$6	net/minecraft/class_385$6
 FIELD	cjz$6	Lcjz;	o	field_20302
-CLASS	ck	net/minecraft/class_4159
+CLASS	ck	net/minecraft/class_4160
 FIELD	ck	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_20303
 FIELD	ck	Ljava/util/Collection;	b	field_20304
 METHOD	ck	()Lck;	a	method_18598
@@ -19301,7 +19301,7 @@ METHOD	ckl$b	(Lwr;)V	a	method_18636
 METHOD	ckl$b	(Lwr;)I	b	method_18637
 METHOD	ckl$b	(I)Lata;	c	method_18638
 METHOD	ckl$b	(I)Lwr;	d	method_18639
-CLASS	ckl$b$a	net/minecraft/class_402$class_406$class_4160
+CLASS	ckl$b$a	net/minecraft/class_402$class_406$class_4161
 FIELD	ckl$b$a	Lckl$b;	a	field_20345
 METHOD	ckl$b$a	(Lata;Lata;)I	a	method_18640
 METHOD	ckl$b$a	(Ljava/lang/Object;Ljava/lang/Object;)I	compare	compare
@@ -19426,7 +19426,7 @@ CLASS	cku$a	net/minecraft/class_1819$class_1821
 FIELD	cku$a	Lcku;	c	field_7802
 FIELD	cku$a	Ljava/lang/String;	d	field_7803
 FIELD	cku$a	I	e	field_7804
-CLASS	cku$b	net/minecraft/class_1819$class_4161
+CLASS	cku$b	net/minecraft/class_1819$class_4162
 CLASS	cku$c	net/minecraft/class_1819$class_1822
 FIELD	cku$c	Lcku;	c	field_7805
 FIELD	cku$c	Lcfp;	d	field_7806
@@ -19460,7 +19460,7 @@ CLASS	ckv$2	net/minecraft/class_362$2
 FIELD	ckv$2	Lckv;	o	field_20355
 CLASS	ckv$3	net/minecraft/class_362$3
 FIELD	ckv$3	Lckv;	o	field_20356
-CLASS	ckx	net/minecraft/class_4162
+CLASS	ckx	net/minecraft/class_4163
 FIELD	ckx	Lcgy;	a	field_20357
 FIELD	ckx	Lcgy;	f	field_20358
 FIELD	ckx	Lcgu;	g	field_20359
@@ -19498,17 +19498,17 @@ METHOD	ckx	()V	o	method_18668
 METHOD	ckx	()V	s	method_18669
 METHOD	ckx	()V	u	method_18670
 METHOD	ckx	()V	v	method_18671
-CLASS	ckx$1	net/minecraft/class_4162$1
+CLASS	ckx$1	net/minecraft/class_4163$1
 FIELD	ckx$1	Lckx;	o	field_20370
-CLASS	ckx$2	net/minecraft/class_4162$2
+CLASS	ckx$2	net/minecraft/class_4163$2
 FIELD	ckx$2	Lckx;	o	field_20371
-CLASS	ckx$3	net/minecraft/class_4162$3
+CLASS	ckx$3	net/minecraft/class_4163$3
 FIELD	ckx$3	Lckx;	o	field_20372
-CLASS	ckx$4	net/minecraft/class_4162$4
+CLASS	ckx$4	net/minecraft/class_4163$4
 FIELD	ckx$4	Lckx;	g	field_20373
-CLASS	ckx$5	net/minecraft/class_4162$5
+CLASS	ckx$5	net/minecraft/class_4163$5
 FIELD	ckx$5	Lckx;	g	field_20374
-CLASS	ckx$a	net/minecraft/class_4162$class_4163
+CLASS	ckx$a	net/minecraft/class_4163$class_4164
 FIELD	ckx$a	Lckx;	a	field_20375
 FIELD	ckx$a	Lcuj;	b	field_20376
 FIELD	ckx$a	Lcom/mojang/brigadier/suggestion/Suggestions;	c	field_20377
@@ -19572,7 +19572,7 @@ FIELD	ckz	Lapw;	x	field_5122
 FIELD	ckz	Lcgy;	y	field_5123
 FIELD	ckz	Laof;	z	field_5124
 METHOD	ckz	(ILjava/lang/String;)V	a	method_18682
-CLASS	cl	net/minecraft/class_4164
+CLASS	cl	net/minecraft/class_4165
 FIELD	cl	Ljava/util/Collection;	a	field_20383
 FIELD	cl	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_20384
 FIELD	cl	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_20385
@@ -19591,9 +19591,9 @@ METHOD	cl	(II)I	f	method_18694
 METHOD	cl	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cl	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	cl	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cl$a	net/minecraft/class_4164$class_4165
+CLASS	cl$a	net/minecraft/class_4165$class_4166
 METHOD	cl$a	(Lcfb;Lcfb;)V	apply	apply
-CLASS	cl$b	net/minecraft/class_4164$class_4166
+CLASS	cl$b	net/minecraft/class_4165$class_4167
 METHOD	cl$b	(II)I	apply	apply
 CLASS	cla	net/minecraft/class_1323
 FIELD	cla	Z	A	field_5108
@@ -19867,7 +19867,7 @@ CLASS	clq$2	net/minecraft/class_423$2
 FIELD	clq$2	Lclq;	o	field_20412
 CLASS	clq$a	net/minecraft/class_423$class_424
 FIELD	clq$a	Z	o	field_1409
-CLASS	clr	net/minecraft/class_4167
+CLASS	clr	net/minecraft/class_4168
 FIELD	clr	Laxh;	z	field_20413
 CLASS	cls	net/minecraft/class_3084
 FIELD	cls	Lpc;	w	field_15253
@@ -20044,7 +20044,7 @@ FIELD	clz	Ldgi;	d	field_7827
 FIELD	clz	Lclx;	e	field_7828
 FIELD	clz	J	f	field_7829
 METHOD	clz	()Ldgi;	e	method_6786
-CLASS	cm	net/minecraft/class_4168
+CLASS	cm	net/minecraft/class_4169
 FIELD	cm	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_20440
 FIELD	cm	Ljava/util/Collection;	b	field_20441
 METHOD	cm	()Lcm;	a	method_18780
@@ -20084,7 +20084,7 @@ METHOD	cmb	(Ljava/util/List;)V	a	method_6792
 METHOD	cmb	(I)V	c	method_6793
 METHOD	cmb	()I	g	method_6794
 METHOD	cmb	()V	h	method_18787
-CLASS	cmb$a	net/minecraft/class_1827$class_4169
+CLASS	cmb$a	net/minecraft/class_1827$class_4170
 CLASS	cme	net/minecraft/class_3278
 FIELD	cme	Lavk;	a	field_16023
 FIELD	cme	Ljava/util/List;	b	field_16024
@@ -20134,12 +20134,12 @@ FIELD	cmf$a	Lavk;	q	field_16040
 FIELD	cmf$a	Z	r	field_16041
 METHOD	cmf$a	(Lavk;)V	a	method_18790
 METHOD	cmf$a	(Lcmf$a;)Lavk;	a	method_14572
-CLASS	cmf$a$a	net/minecraft/class_3280$class_3281$class_4170
+CLASS	cmf$a$a	net/minecraft/class_3280$class_3281$class_4171
 FIELD	cmf$a$a	[Late;	a	field_20445
 FIELD	cmf$a$a	I	b	field_20446
 FIELD	cmf$a$a	I	c	field_20447
 FIELD	cmf$a$a	Lcmf$a;	d	field_20448
-CLASS	cmf$b	net/minecraft/class_3280$class_4171
+CLASS	cmf$b	net/minecraft/class_3280$class_4172
 FIELD	cmf$b	Lcmf;	q	field_20449
 CLASS	cmg	net/minecraft/class_3282
 FIELD	cmg	Lpc;	a	field_16042
@@ -20263,7 +20263,7 @@ METHOD	cml	(Ljava/util/List;)V	a	method_14636
 CLASS	cmm	net/minecraft/class_3288
 METHOD	cmm	()V	ai_	method_14637
 METHOD	cmm	()Lcmg;	i	method_14638
-CLASS	cmn	net/minecraft/class_4172
+CLASS	cmn	net/minecraft/class_4173
 FIELD	cmn	Ljava/util/Iterator;	m	field_20459
 FIELD	cmn	Ljava/util/Set;	n	field_20460
 FIELD	cmn	Laqx;	o	field_20461
@@ -20435,34 +20435,34 @@ CLASS	cmz$6	net/minecraft/class_387$6
 FIELD	cmz$6	Lcmz;	o	field_20489
 CLASS	cmz$7	net/minecraft/class_387$7
 FIELD	cmz$7	Lcmz;	o	field_20490
-CLASS	cn	net/minecraft/class_4173
+CLASS	cn	net/minecraft/class_4174
 METHOD	cn	()Lcn$b;	a	method_18871
-CLASS	cn$a	net/minecraft/class_4173$class_4174
+CLASS	cn$a	net/minecraft/class_4174$class_4175
 FIELD	cn$a	Ljava/util/Collection;	a	field_20491
 METHOD	cn$a	(Lcom/mojang/brigadier/StringReader;)Lba$c;	a	method_18872
 METHOD	cn$a	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cn$a	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cn$a$a	net/minecraft/class_4173$class_4174$class_4175
+CLASS	cn$a$a	net/minecraft/class_4174$class_4175$class_4176
 METHOD	cn$a$a	(Lhy;)Lcn$a;	a	method_18873
-CLASS	cn$b	net/minecraft/class_4173$class_4176
+CLASS	cn$b	net/minecraft/class_4174$class_4177
 FIELD	cn$b	Ljava/util/Collection;	a	field_20492
 METHOD	cn$b	(Lcom/mojang/brigadier/StringReader;)Lba$d;	a	method_18874
 METHOD	cn$b	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lba$d;	a	method_18875
 METHOD	cn$b	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cn$b	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cn$b$a	net/minecraft/class_4173$class_4176$class_4177
+CLASS	cn$b$a	net/minecraft/class_4174$class_4177$class_4178
 METHOD	cn$b$a	(Lhy;)Lcn$b;	a	method_18876
-CLASS	cn$c	net/minecraft/class_4173$class_4178
+CLASS	cn$c	net/minecraft/class_4174$class_4179
 METHOD	cn$c	(Lcn;Lcom/google/gson/JsonObject;)V	a	method_18877
 METHOD	cn$c	(Lcn;Lhy;)V	a	method_18878
-CLASS	cna	net/minecraft/class_4179
+CLASS	cna	net/minecraft/class_4180
 FIELD	cna	Lit/unimi/dsi/fastutil/objects/Object2IntMap;	a	field_20493
 FIELD	cna	Lcji;	f	field_20494
 FIELD	cna	Lada;	g	field_20495
 METHOD	cna	(Lcna;)Lada;	a	method_18879
 METHOD	cna	(Lit/unimi/dsi/fastutil/objects/Object2IntOpenCustomHashMap;)V	a	method_18880
 METHOD	cna	(Lcna;)Lcji;	b	method_18881
-CLASS	cna$1	net/minecraft/class_4179$1
+CLASS	cna$1	net/minecraft/class_4180$1
 FIELD	cna$1	Lcna;	o	field_20496
 CLASS	cnb	net/minecraft/class_391
 FIELD	cnb	Lckd;	a	field_1261
@@ -20624,7 +20624,7 @@ FIELD	cnq$e	Lcga;	a	field_10536
 FIELD	cnq$e	Lcom/mojang/authlib/properties/PropertyMap;	b	field_20510
 FIELD	cnq$e	Lcom/mojang/authlib/properties/PropertyMap;	c	field_10538
 FIELD	cnq$e	Ljava/net/Proxy;	d	field_10539
-CLASS	cnv	net/minecraft/class_4180
+CLASS	cnv	net/minecraft/class_4181
 FIELD	cnv	Lcqw;	a	field_20511
 FIELD	cnv	Lcqw;	b	field_20512
 FIELD	cnv	Lcqw;	c	field_20513
@@ -20656,7 +20656,7 @@ FIELD	cnz	Lcqw;	c	field_5127
 FIELD	cnz	Lcqw;	d	field_5128
 FIELD	cnz	Lcqw;	e	field_5129
 FIELD	cnz	Lcqw;	f	field_5130
-CLASS	co	net/minecraft/class_4181
+CLASS	co	net/minecraft/class_4182
 FIELD	co	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_20520
 FIELD	co	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_20521
 FIELD	co	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_20522
@@ -20700,7 +20700,7 @@ FIELD	coe	Lcqw;	b	field_1452
 FIELD	coe	Lcqw;	c	field_1453
 METHOD	coe	()V	a	method_1169
 METHOD	coe	()Lcqw;	b	method_18912
-CLASS	cof	net/minecraft/class_4182
+CLASS	cof	net/minecraft/class_4183
 FIELD	cof	Lcqw;	c	field_20524
 FIELD	cof	Lcqw;	d	field_20525
 CLASS	cog	net/minecraft/class_435
@@ -20712,7 +20712,7 @@ FIELD	cog	Lcqw;	e	field_1458
 FIELD	cog	Lcqw;	f	field_1459
 FIELD	cog	Lcqw;	g	field_1460
 FIELD	cog	Lcqw;	h	field_1461
-CLASS	coh	net/minecraft/class_4183
+CLASS	coh	net/minecraft/class_4184
 FIELD	coh	Lcqw;	a	field_20526
 FIELD	coh	Lcqw;	b	field_20527
 FIELD	coh	Lcqw;	c	field_20528
@@ -20720,7 +20720,7 @@ FIELD	coh	Lcqw;	d	field_20529
 FIELD	coh	Lcqw;	e	field_20530
 FIELD	coh	Lcqw;	f	field_20531
 FIELD	coh	Lcqw;	g	field_20532
-CLASS	coi	net/minecraft/class_4184
+CLASS	coi	net/minecraft/class_4185
 METHOD	coi	()Lcqw;	a	method_18913
 CLASS	coj	net/minecraft/class_437
 FIELD	coj	Lcqw;	a	field_1462
@@ -20730,7 +20730,7 @@ FIELD	coj	Lcqw;	d	field_1465
 FIELD	coj	Lcqw;	e	field_1466
 FIELD	coj	Lcqw;	f	field_1467
 FIELD	coj	Lcqw;	g	field_1468
-CLASS	cok	net/minecraft/class_4185
+CLASS	cok	net/minecraft/class_4186
 CLASS	col	net/minecraft/class_2849
 FIELD	col	Lcqw;	a	field_13382
 FIELD	col	Lcqw;	b	field_13383
@@ -20816,7 +20816,7 @@ FIELD	coy	Lcqw;	a	field_6395
 CLASS	coz	net/minecraft/class_3088
 FIELD	coz	Lcqw;	i	field_15267
 FIELD	coz	Lcqw;	j	field_15268
-CLASS	cp	net/minecraft/class_4186
+CLASS	cp	net/minecraft/class_4187
 FIELD	cp	Lcom/mojang/brigadier/suggestion/SuggestionProvider;	a	field_20535
 FIELD	cp	Ljava/util/Collection;	b	field_20536
 FIELD	cp	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_20537
@@ -20835,11 +20835,11 @@ METHOD	cp	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava
 METHOD	cp	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/Collection;	c	method_18930
 METHOD	cp	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cp	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cp$a	net/minecraft/class_4186$class_4187
+CLASS	cp$a	net/minecraft/class_4187$class_4188
 METHOD	cp$a	(Lbu;Ljava/util/function/Supplier;)Ljava/util/Collection;	getNames	getNames
-CLASS	cp$b	net/minecraft/class_4186$class_4188
+CLASS	cp$b	net/minecraft/class_4187$class_4189
 FIELD	cp$b	Ldr;	a	field_20539
-CLASS	cp$c	net/minecraft/class_4186$class_4189
+CLASS	cp$c	net/minecraft/class_4187$class_4190
 METHOD	cp$c	(Lcp;Lcom/google/gson/JsonObject;)V	a	method_18931
 METHOD	cp$c	(Lcp;Lhy;)V	a	method_18932
 METHOD	cp$c	(Lhy;)Lcp;	a	method_18933
@@ -20895,7 +20895,7 @@ FIELD	cpe$a	Lcpe$a;	e	field_20540
 FIELD	cpe$a	[Lcpe$a;	f	field_16110
 METHOD	cpe$a	(Ljava/lang/String;)Lcpe$a;	valueOf	valueOf
 METHOD	cpe$a	()[Lcpe$a;	values	values
-CLASS	cpf	net/minecraft/class_4190
+CLASS	cpf	net/minecraft/class_4191
 FIELD	cpf	Lcqw;	a	field_20541
 FIELD	cpf	Lcqw;	b	field_20542
 FIELD	cpf	Lcqw;	c	field_20543
@@ -20923,7 +20923,7 @@ FIELD	cpj	I	b	field_1506
 FIELD	cpj	Z	c	field_1507
 METHOD	cpj	()V	a	method_1178
 METHOD	cpj	(Lctq;F)V	a	method_9644
-CLASS	cpk	net/minecraft/class_4191
+CLASS	cpk	net/minecraft/class_4192
 FIELD	cpk	Lcqw;	a	field_20549
 FIELD	cpk	Lcqw;	b	field_20550
 FIELD	cpk	Lcqw;	c	field_20551
@@ -20937,7 +20937,7 @@ FIELD	cpk	Lcqw;	j	field_20558
 FIELD	cpk	Lcqw;	k	field_20559
 FIELD	cpk	Lcqw;	l	field_20560
 FIELD	cpk	Lcqw;	m	field_20561
-CLASS	cpl	net/minecraft/class_4192
+CLASS	cpl	net/minecraft/class_4193
 FIELD	cpl	Lcqw;	a	field_20562
 FIELD	cpl	Lcqw;	b	field_20563
 FIELD	cpl	Lcqw;	c	field_20564
@@ -20949,7 +20949,7 @@ FIELD	cpl	Lcqw;	h	field_20569
 FIELD	cpl	Lcqw;	i	field_20570
 FIELD	cpl	Lcqw;	j	field_20571
 FIELD	cpl	Lcqw;	k	field_20572
-CLASS	cpm	net/minecraft/class_4193
+CLASS	cpm	net/minecraft/class_4194
 FIELD	cpm	Lcqw;	a	field_20573
 FIELD	cpm	Lcqw;	b	field_20574
 FIELD	cpm	Lcqw;	c	field_20575
@@ -20980,7 +20980,7 @@ FIELD	cpo	Lcqw;	k	field_10578
 FIELD	cpo	Lcqw;	l	field_10579
 FIELD	cpo	F	m	field_10580
 METHOD	cpo	(Lcqw;FFF)V	a	method_9645
-CLASS	cpp	net/minecraft/class_4194
+CLASS	cpp	net/minecraft/class_4195
 FIELD	cpp	Lcqw;	a	field_20579
 FIELD	cpp	Lcqw;	b	field_20580
 FIELD	cpp	Lcqw;	c	field_20581
@@ -20999,7 +20999,7 @@ FIELD	cps	Lcqw;	b	field_13393
 METHOD	cps	()V	a	method_12224
 CLASS	cpt	net/minecraft/class_2852
 FIELD	cpt	Lcqw;	a	field_13394
-CLASS	cpu	net/minecraft/class_4195
+CLASS	cpu	net/minecraft/class_4196
 FIELD	cpu	Lcqw;	a	field_20587
 FIELD	cpu	Lcqw;	b	field_20588
 FIELD	cpu	Lcqw;	c	field_20589
@@ -21025,7 +21025,7 @@ FIELD	cpz	Lcqw;	a	field_1526
 FIELD	cpz	Lcqw;	b	field_1527
 FIELD	cpz	Lcqw;	c	field_1528
 FIELD	cpz	Lcqw;	d	field_1529
-CLASS	cq	net/minecraft/class_4196
+CLASS	cq	net/minecraft/class_4197
 FIELD	cq	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_20590
 FIELD	cq	Ljava/util/Collection;	b	field_20591
 METHOD	cq	()Lcq;	a	method_18938
@@ -21057,24 +21057,24 @@ FIELD	cqb	Lcqw;	k	field_1545
 CLASS	cqc	net/minecraft/class_458
 FIELD	cqc	Lcqw;	a	field_1546
 FIELD	cqc	[Lcqw;	b	field_1547
-CLASS	cqd	net/minecraft/class_4197
+CLASS	cqd	net/minecraft/class_4198
 FIELD	cqd	Lpc;	a	field_20592
 FIELD	cqd	Lcqw;	b	field_20593
 METHOD	cqd	()V	a	method_18943
-CLASS	cqe	net/minecraft/class_4198
+CLASS	cqe	net/minecraft/class_4199
 FIELD	cqe	Lcqw;	a	field_20594
 FIELD	cqe	Lcqw;	b	field_20595
 FIELD	cqe	Lcqw;	c	field_20596
 FIELD	cqe	Lcqw;	d	field_20597
 FIELD	cqe	Lcqw;	e	field_20598
-CLASS	cqf	net/minecraft/class_4199
+CLASS	cqf	net/minecraft/class_4200
 FIELD	cqf	Lcqw;	a	field_20599
 FIELD	cqf	Lcqw;	b	field_20600
 FIELD	cqf	Lcqw;	c	field_20601
 FIELD	cqf	Lcqw;	d	field_20602
 FIELD	cqf	Lcqw;	e	field_20603
 FIELD	cqf	Lcqw;	f	field_20604
-CLASS	cqg	net/minecraft/class_4200
+CLASS	cqg	net/minecraft/class_4201
 FIELD	cqg	Lcqw;	i	field_20605
 CLASS	cqh	net/minecraft/class_2854
 METHOD	cqh	(Laer;FFFFFF)V	b	method_12226
@@ -21095,7 +21095,7 @@ FIELD	cqk	Lcqw;	e	field_1561
 FIELD	cqk	Lcqw;	f	field_5132
 METHOD	cqk	()Lcqw;	a	method_18944
 CLASS	cql	net/minecraft/class_1334
-CLASS	cqm	net/minecraft/class_4201
+CLASS	cqm	net/minecraft/class_4202
 FIELD	cqm	Z	g	field_20606
 FIELD	cqm	Lcqw;	h	field_20607
 FIELD	cqm	Lcqw;	i	field_20608
@@ -21187,7 +21187,7 @@ METHOD	cqw	(F)V	d	method_1196
 CLASS	cqx	net/minecraft/class_468
 FIELD	cqx	I	a	field_1614
 FIELD	cqx	I	b	field_1615
-CLASS	cr	net/minecraft/class_4202
+CLASS	cr	net/minecraft/class_4203
 FIELD	cr	Ljava/util/Collection;	a	field_20609
 FIELD	cr	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_20610
 FIELD	cr	Ljava/util/Map;	c	field_20611
@@ -21281,7 +21281,7 @@ FIELD	crd$2	[I	a	field_20618
 FIELD	crd$2	[I	b	field_20619
 FIELD	crd$2	[I	c	field_20620
 FIELD	crd$2	[I	d	field_20621
-CLASS	cre	net/minecraft/class_4203
+CLASS	cre	net/minecraft/class_4204
 FIELD	cre	Lcrd;	a	field_20622
 FIELD	cre	Lcft;	b	field_20623
 FIELD	cre	I	c	field_20624
@@ -21500,14 +21500,14 @@ CLASS	crq$b	net/minecraft/class_487$class_2350
 METHOD	crq$b	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18982
 CLASS	crq$c	net/minecraft/class_487$class_2351
 METHOD	crq$c	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18983
-CLASS	crr	net/minecraft/class_4204
-CLASS	crr$a	net/minecraft/class_4204$class_4205
+CLASS	crr	net/minecraft/class_4205
+CLASS	crr$a	net/minecraft/class_4205$class_4206
 METHOD	crr$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18984
 CLASS	crs	net/minecraft/class_488
 CLASS	crs$a	net/minecraft/class_488$class_2352
 METHOD	crs$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18985
-CLASS	crt	net/minecraft/class_4206
-CLASS	crt$a	net/minecraft/class_4206$class_4207
+CLASS	crt	net/minecraft/class_4207
+CLASS	crt$a	net/minecraft/class_4207$class_4208
 METHOD	crt$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18986
 CLASS	cru	net/minecraft/class_489
 FIELD	cru	F	J	field_10610
@@ -21537,14 +21537,14 @@ CLASS	cry	net/minecraft/class_492
 FIELD	cry	D	J	field_1704
 FIELD	cry	D	K	field_1705
 FIELD	cry	D	L	field_1706
-CLASS	cry$a	net/minecraft/class_492$class_4208
+CLASS	cry$a	net/minecraft/class_492$class_4209
 METHOD	cry$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18994
 CLASS	cry$b	net/minecraft/class_492$class_2357
 METHOD	cry$b	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18995
 CLASS	crz	net/minecraft/class_2861
 CLASS	crz$a	net/minecraft/class_2861$class_2862
 METHOD	crz$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_18996
-CLASS	cs	net/minecraft/class_4209
+CLASS	cs	net/minecraft/class_4210
 FIELD	cs	Ljava/util/Collection;	a	field_20629
 FIELD	cs	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_20630
 METHOD	cs	()Lcs;	a	method_18997
@@ -21777,14 +21777,14 @@ METHOD	csu$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19029
 CLASS	csv	net/minecraft/class_510
 CLASS	csv$a	net/minecraft/class_510$class_2383
 METHOD	csv$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19030
-CLASS	csw	net/minecraft/class_4210
-CLASS	csw$a	net/minecraft/class_4210$class_4211
+CLASS	csw	net/minecraft/class_4211
+CLASS	csw$a	net/minecraft/class_4211$class_4212
 METHOD	csw$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19031
 CLASS	csx	net/minecraft/class_511
 CLASS	csx$a	net/minecraft/class_511$class_2384
 METHOD	csx$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19032
 CLASS	csy	net/minecraft/class_512
-CLASS	csy$a	net/minecraft/class_512$class_4212
+CLASS	csy$a	net/minecraft/class_512$class_4213
 METHOD	csy$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19033
 CLASS	csy$b	net/minecraft/class_512$class_2385
 METHOD	csy$b	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19034
@@ -21798,7 +21798,7 @@ METHOD	csz	(Lel;)V	b	method_12261
 METHOD	csz	()Lcsz;	n	method_12262
 CLASS	csz$a	net/minecraft/class_514$class_2388
 METHOD	csz$a	(Lfh;Laxy;DDDDDD)Lcsm;	a	method_19036
-CLASS	ct	net/minecraft/class_4213
+CLASS	ct	net/minecraft/class_4214
 FIELD	ct	Lblc;	a	field_20633
 FIELD	ct	Ljava/util/Set;	b	field_20634
 FIELD	ct	Lgy;	c	field_20635
@@ -21817,9 +21817,9 @@ FIELD	ctb	Lfk;	M	field_10622
 CLASS	ctc	net/minecraft/class_1857
 CLASS	ctc$a	net/minecraft/class_1857$class_2390
 METHOD	ctc$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19041
-CLASS	ctd	net/minecraft/class_4214
+CLASS	ctd	net/minecraft/class_4215
 FIELD	ctd	F	J	field_20636
-CLASS	ctd$a	net/minecraft/class_4214$class_4215
+CLASS	ctd$a	net/minecraft/class_4215$class_4216
 METHOD	ctd$a	(Lfn;Laxy;DDDDDD)Lcsm;	a	method_19042
 CLASS	cte	net/minecraft/class_515
 CLASS	cte$a	net/minecraft/class_515$class_2391
@@ -22004,7 +22004,7 @@ METHOD	ctt	(DDD)V	a	method_9768
 METHOD	ctt	(Laxl;)V	a	method_9769
 METHOD	ctt	(Lcwt;)V	a	method_9770
 METHOD	ctt	(Lcwt;Laxl;)V	a	method_9771
-CLASS	ctu	net/minecraft/class_4216
+CLASS	ctu	net/minecraft/class_4217
 FIELD	ctu	[Lpc;	a	field_20642
 METHOD	ctu	(Lcft;FF)V	a	method_19048
 CLASS	ctv	net/minecraft/class_2399
@@ -22050,7 +22050,7 @@ CLASS	ctw$b	net/minecraft/class_2400$class_2402
 FIELD	ctw$b	I	a	field_10692
 FIELD	ctw$b	I	b	field_10693
 FIELD	ctw$b	I	c	field_10694
-CLASS	ctx	net/minecraft/class_4217
+CLASS	ctx	net/minecraft/class_4218
 FIELD	ctx	Ljava/nio/FloatBuffer;	a	field_20647
 FIELD	ctx	Ljava/nio/FloatBuffer;	b	field_20648
 FIELD	ctx	F	c	field_20649
@@ -22070,7 +22070,7 @@ METHOD	ctx	(IF)V	a	method_19054
 METHOD	ctx	(Laer;Laxy;F)V	a	method_19055
 METHOD	ctx	(Laer;Layc;F)V	a	method_19056
 METHOD	ctx	(Z)V	a	method_19057
-CLASS	cty	net/minecraft/class_4218
+CLASS	cty	net/minecraft/class_4219
 FIELD	cty	Lctx;	A	field_20660
 FIELD	cty	Z	B	field_20661
 FIELD	cty	D	C	field_20662
@@ -22155,7 +22155,7 @@ METHOD	cty	()Z	p	method_19095
 METHOD	cty	()V	q	method_19096
 METHOD	cty	()Ljava/lang/String;	r	method_19097
 METHOD	cty	()Ljava/lang/String;	s	method_19098
-CLASS	ctz	net/minecraft/class_4219
+CLASS	ctz	net/minecraft/class_4220
 FIELD	ctz	Ljava/nio/ByteBuffer;	a	field_20702
 FIELD	ctz	Ljava/nio/FloatBuffer;	b	field_20703
 FIELD	ctz	Ljava/nio/IntBuffer;	c	field_20704
@@ -22174,7 +22174,7 @@ METHOD	ctz	(I)Ljava/lang/String;	c	method_19103
 METHOD	ctz	(I)Ljava/lang/String;	d	method_19104
 METHOD	ctz	(I)Ljava/lang/String;	e	method_19105
 METHOD	ctz	(I)Ljava/lang/String;	f	method_19106
-CLASS	cu	net/minecraft/class_4220
+CLASS	cu	net/minecraft/class_4221
 FIELD	cu	Ljava/util/Collection;	a	field_20712
 FIELD	cu	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_20713
 METHOD	cu	()Lcu;	a	method_19107
@@ -22186,16 +22186,16 @@ METHOD	cu	(Lpc;Lcw;Lxb;)Ljava/util/function/Predicate;	a	method_19112
 METHOD	cu	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cu	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	cu	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cu$1	net/minecraft/class_4220$1
-CLASS	cu$a	net/minecraft/class_4220$class_4221
+CLASS	cu$1	net/minecraft/class_4221$1
+CLASS	cu$a	net/minecraft/class_4221$class_4222
 FIELD	cu$a	Lblc;	a	field_20714
 FIELD	cu$a	Ljava/util/Set;	b	field_20715
 FIELD	cu$a	Lgy;	c	field_20716
 METHOD	cu$a	(Lblh;)Z	a	method_19113
 METHOD	cu$a	(Ljava/lang/Object;)Z	test	test
-CLASS	cu$b	net/minecraft/class_4220$class_4222
+CLASS	cu$b	net/minecraft/class_4221$class_4223
 METHOD	cu$b	(Lxb;)Ljava/util/function/Predicate;	create	create
-CLASS	cu$c	net/minecraft/class_4220$class_4223
+CLASS	cu$c	net/minecraft/class_4221$class_4224
 FIELD	cu$c	Lwz;	a	field_20717
 FIELD	cu$c	Lgy;	b	field_20718
 FIELD	cu$c	Ljava/util/Map;	c	field_20719
@@ -22523,7 +22523,7 @@ FIELD	cua$w	Lcua$v;	d	field_10788
 CLASS	cua$x	net/minecraft/class_2403$class_2421
 FIELD	cua$x	Lcua$c;	a	field_10789
 FIELD	cua$x	I	b	field_10790
-CLASS	cua$y	net/minecraft/class_2403$class_4224
+CLASS	cua$y	net/minecraft/class_2403$class_4225
 FIELD	cua$y	Lcua$y;	a	field_20722
 FIELD	cua$y	I	b	field_20723
 FIELD	cua$y	I	c	field_20724
@@ -22535,7 +22535,7 @@ METHOD	cua$y	()[Lcua$y;	values	values
 CLASS	cub	net/minecraft/class_527
 METHOD	cub	()V	a	method_6885
 METHOD	cub	(Lddg;)Lddg;	a	method_19128
-CLASS	cuc	net/minecraft/class_4225
+CLASS	cuc	net/minecraft/class_4226
 FIELD	cuc	Lpc;	a	field_20728
 FIELD	cuc	Lpc;	b	field_20729
 FIELD	cuc	Lcft;	c	field_20730
@@ -22570,7 +22570,7 @@ METHOD	cuc	(F)V	c	method_19148
 METHOD	cuc	()V	d	method_19149
 METHOD	cuc	(F)F	d	method_19150
 METHOD	cuc	(F)V	e	method_19151
-CLASS	cuc$1	net/minecraft/class_4225$1
+CLASS	cuc$1	net/minecraft/class_4226$1
 FIELD	cuc$1	[I	a	field_10793
 CLASS	cud	net/minecraft/class_2422
 FIELD	cud	Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;	a	field_20739
@@ -22725,7 +22725,7 @@ METHOD	cue$a	(Leq;)Z	a	method_12341
 METHOD	cue$a	(Lcue$a;)Leq;	b	method_19167
 METHOD	cue$a	(Lcue$a;)I	c	method_19168
 METHOD	cue$a	(Lcue$a;)B	d	method_19169
-CLASS	cuf	net/minecraft/class_4226
+CLASS	cuf	net/minecraft/class_4227
 FIELD	cuf	Lddb;	a	field_20756
 FIELD	cuf	Lddg;	b	field_20757
 FIELD	cuf	Lpc;	c	field_20758
@@ -22743,12 +22743,12 @@ CLASS	cug	net/minecraft/class_531
 METHOD	cug	(Lddg;IIII)V	a	method_19174
 METHOD	cug	(Lddg;IIII)V	b	method_19175
 CLASS	cuh	net/minecraft/class_532
-CLASS	cui	net/minecraft/class_4227
+CLASS	cui	net/minecraft/class_4228
 FIELD	cui	Lcft;	a	field_20764
 FIELD	cui	Lctu;	b	field_20765
 FIELD	cui	F	c	field_20766
 METHOD	cui	(F)V	a	method_19176
-CLASS	cuj	net/minecraft/class_4228
+CLASS	cuj	net/minecraft/class_4229
 FIELD	cuj	I	a	field_20767
 FIELD	cuj	I	b	field_20768
 FIELD	cuj	I	c	field_20769
@@ -23004,7 +23004,7 @@ METHOD	cuz$a	(Lcom/google/gson/JsonObject;)I	a	method_9996
 METHOD	cuz$a	(Lcom/google/gson/JsonObject;)Ljava/lang/String;	b	method_9997
 METHOD	cuz$a	(Lcom/google/gson/JsonObject;)Leq;	c	method_9998
 METHOD	cuz$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
-CLASS	cv	net/minecraft/class_4229
+CLASS	cv	net/minecraft/class_4230
 FIELD	cv	Ljava/util/Collection;	a	field_20779
 METHOD	cv	()Lcv;	a	method_19207
 METHOD	cv	(Lcom/mojang/brigadier/StringReader;)Lct;	a	method_19208
@@ -23012,7 +23012,7 @@ METHOD	cv	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lct;	
 METHOD	cv	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cv	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	cv	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cva	net/minecraft/class_4230
+CLASS	cva	net/minecraft/class_4231
 FIELD	cva	Ldhl;	a	field_20780
 FIELD	cva	Leq$a;	b	field_20781
 FIELD	cva	F	c	field_20782
@@ -23030,7 +23030,7 @@ METHOD	cvb$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/g
 METHOD	cvb$a	(Lcom/google/gson/JsonObject;)I	a	method_10005
 METHOD	cvb$a	(Lcom/google/gson/JsonObject;)[F	b	method_10006
 METHOD	cvb$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
-CLASS	cvc	net/minecraft/class_4231
+CLASS	cvc	net/minecraft/class_4232
 FIELD	cvc	Lcom/google/gson/Gson;	a	field_20784
 FIELD	cvc	Ljava/lang/String;	b	field_20785
 FIELD	cvc	Ljava/util/Map;	c	field_20786
@@ -23066,11 +23066,11 @@ METHOD	cvc	()Ljava/util/List;	e	method_19228
 METHOD	cvc	()Lcvc;	g	method_19229
 METHOD	cvc	()Lcvk;	h	method_19230
 METHOD	cvc	()Z	i	method_19231
-CLASS	cvc$1	net/minecraft/class_4231$1
-CLASS	cvc$a	net/minecraft/class_4231$class_2446
+CLASS	cvc$1	net/minecraft/class_4232$1
+CLASS	cvc$a	net/minecraft/class_4232$class_2446
 FIELD	cvc$a	Lcvc;	a	field_10937
 FIELD	cvc$a	Lcvc;	b	field_10938
-CLASS	cvc$b	net/minecraft/class_4231$class_2447
+CLASS	cvc$b	net/minecraft/class_4232$class_2447
 METHOD	cvc$b	(Lcom/google/gson/JsonDeserializationContext;Lcom/google/gson/JsonObject;)Ljava/util/List;	a	method_12355
 METHOD	cvc$b	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lcvc;	a	method_10025
 METHOD	cvc$b	(Lcom/google/gson/JsonObject;)Z	a	method_10026
@@ -23087,7 +23087,7 @@ METHOD	cvd	()Z	c	method_12357
 METHOD	cvd	()Lcvq;	d	method_12359
 METHOD	cvd	(Ljava/lang/Object;)Z	equals	equals
 METHOD	cvd	()I	hashCode	hashCode
-CLASS	cvd$a	net/minecraft/class_2449$class_4232
+CLASS	cvd$a	net/minecraft/class_2449$class_4233
 FIELD	cvd$a	Lcom/google/gson/Gson;	a	field_20797
 FIELD	cvd$a	Lble;	b	field_20798
 METHOD	cvd$a	()Lble;	a	method_19234
@@ -23100,7 +23100,7 @@ METHOD	cvd$b	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/g
 CLASS	cve	net/minecraft/class_2455
 FIELD	cve	Lddm;	e	field_10948
 METHOD	cve	()V	f	method_12362
-CLASS	cvf	net/minecraft/class_4233
+CLASS	cvf	net/minecraft/class_4234
 FIELD	cvf	F	a	field_20799
 FIELD	cvf	F	b	field_20800
 FIELD	cvf	[Lcvf$a;	c	field_20801
@@ -23123,14 +23123,14 @@ METHOD	cvf	([IIILdhl;ILddm;Lcvb;)V	a	method_19247
 METHOD	cvf	([IILeq;Lcvb;[FLddm;Ldfa;Lcva;Z)V	a	method_19248
 METHOD	cvf	([ILeq;)V	a	method_19249
 METHOD	cvf	(Leq;)F	b	method_19250
-CLASS	cvf$1	net/minecraft/class_4233$1
-CLASS	cvf$2	net/minecraft/class_4233$2
-CLASS	cvf$3	net/minecraft/class_4233$3
-CLASS	cvf$4	net/minecraft/class_4233$4
-CLASS	cvf$5	net/minecraft/class_4233$5
+CLASS	cvf$1	net/minecraft/class_4234$1
+CLASS	cvf$2	net/minecraft/class_4234$2
+CLASS	cvf$3	net/minecraft/class_4234$3
+CLASS	cvf$4	net/minecraft/class_4234$4
+CLASS	cvf$5	net/minecraft/class_4234$5
 FIELD	cvf$5	[I	a	field_13560
 FIELD	cvf$5	[I	b	field_13561
-CLASS	cvf$a	net/minecraft/class_4233$class_2873
+CLASS	cvf$a	net/minecraft/class_4234$class_2873
 METHOD	cvf$a	(FFFF)Lcvb;	a	method_12366
 METHOD	cvf$a	(Lcvb;)Lcvb;	a	method_12367
 CLASS	cvg	net/minecraft/class_2457
@@ -23241,13 +23241,13 @@ FIELD	cvk$b	Lcvk$b;	i	field_10998
 FIELD	cvk$b	[Lcvk$b;	j	field_10999
 METHOD	cvk$b	(Ljava/lang/String;)Lcvk$b;	valueOf	valueOf
 METHOD	cvk$b	()[Lcvk$b;	values	values
-CLASS	cvl	net/minecraft/class_4234
+CLASS	cvl	net/minecraft/class_4235
 FIELD	cvl	Ljava/util/List;	a	field_20822
 METHOD	cvl	()Ljava/util/List;	a	method_19258
 METHOD	cvl	(Ljava/util/function/Function;Ljava/util/Set;Lpc;)Ljava/util/stream/Stream;	a	method_19259
 METHOD	cvl	(Ljava/lang/Object;)Z	equals	equals
 METHOD	cvl	()I	hashCode	hashCode
-CLASS	cvl$a	net/minecraft/class_4234$class_2878
+CLASS	cvl$a	net/minecraft/class_4235$class_2878
 METHOD	cvl$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lcvl;	a	method_12376
 METHOD	cvl$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
 CLASS	cvm	net/minecraft/class_2452
@@ -23274,7 +23274,7 @@ FIELD	cvn	Ljava/lang/Iterable;	a	field_13573
 METHOD	cvn	(Lblc;Ljava/util/function/Predicate;)Z	a	method_19261
 METHOD	cvn	(Lble;Lcvo;)Ljava/util/function/Predicate;	a	method_19262
 METHOD	cvn	(Ljava/util/List;Lblc;)Z	a	method_19263
-CLASS	cvo	net/minecraft/class_4235
+CLASS	cvo	net/minecraft/class_4236
 FIELD	cvo	Lcvo;	FALSE	FALSE
 FIELD	cvo	Lcvo;	TRUE	TRUE
 METHOD	cvo	(Lble;)Ljava/util/function/Predicate;	getPredicate	getPredicate
@@ -23292,7 +23292,7 @@ METHOD	cvp	(Lbmm;Ljava/util/Optional;Lblc;)Z	a	method_19266
 METHOD	cvp	(Ljava/util/List;Lblc;)Z	a	method_19267
 METHOD	cvp	(Lble;Lbmm;Ljava/lang/String;)Ljava/util/function/Predicate;	b	method_19268
 METHOD	cvp	()Ljava/lang/String;	toString	toString
-CLASS	cvq	net/minecraft/class_4236
+CLASS	cvq	net/minecraft/class_4237
 FIELD	cvq	Lble;	a	field_20823
 FIELD	cvq	Ljava/util/List;	b	field_20824
 METHOD	cvq	()Ljava/util/List;	a	method_19269
@@ -23301,7 +23301,7 @@ METHOD	cvq	(Ljava/util/function/Function;Ljava/util/Set;Lcvs;)Ljava/util/stream/
 METHOD	cvq	()Ljava/util/Set;	b	method_19272
 METHOD	cvq	(Ljava/lang/Object;)Z	equals	equals
 METHOD	cvq	()I	hashCode	hashCode
-CLASS	cvq$a	net/minecraft/class_4236$class_2883
+CLASS	cvq$a	net/minecraft/class_4237$class_2883
 FIELD	cvq$a	Lcvd$a;	a	field_20825
 METHOD	cvq$a	(Lcom/google/gson/JsonDeserializationContext;Lcom/google/gson/JsonArray;)Ljava/util/List;	a	method_12390
 METHOD	cvq$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lcvq;	a	method_12391
@@ -23318,7 +23318,7 @@ METHOD	cvs	()Lcvl;	a	method_12393
 METHOD	cvs	(Lble;)Ljava/util/function/Predicate;	a	method_19276
 METHOD	cvs	(Ljava/lang/Object;)Z	equals	equals
 METHOD	cvs	()I	hashCode	hashCode
-CLASS	cvs$a	net/minecraft/class_2885$class_4237
+CLASS	cvs$a	net/minecraft/class_2885$class_4238
 METHOD	cvs$a	(Lcom/google/gson/JsonElement;)Lcvo;	a	method_19277
 METHOD	cvs$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lcvs;	a	method_19278
 METHOD	cvs$a	(Lcom/google/gson/JsonObject;)Lcvo;	a	method_19279
@@ -23345,7 +23345,7 @@ METHOD	cvz	(I)[Lpc;	a	method_19284
 METHOD	cvz	(Lasc;)Lpc;	a	method_19285
 METHOD	cvz	(Lbjh;DDDFI)V	a	method_19286
 METHOD	cvz	(ZDDDLeq;)V	a	method_19287
-CLASS	cw	net/minecraft/class_4238
+CLASS	cw	net/minecraft/class_4239
 FIELD	cw	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_20827
 FIELD	cw	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_20828
 FIELD	cw	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	c	field_20829
@@ -23426,7 +23426,7 @@ METHOD	cwa	(Lbji;DDDFIZ)V	a	method_10100
 METHOD	cwa	(Lbji;FI)V	a	method_10101
 METHOD	cwa	(Ljava/lang/Class;)Lcwb;	a	method_1627
 METHOD	cwa	(Lbji;)V	b	method_19324
-CLASS	cwb	net/minecraft/class_4239
+CLASS	cwb	net/minecraft/class_4240
 FIELD	cwb	[Lpc;	a	field_20846
 FIELD	cwb	Lcwa;	b	field_20847
 METHOD	cwb	()Laxy;	a	method_19325
@@ -23450,7 +23450,7 @@ FIELD	cwc	Lcoe;	k	field_2182
 FIELD	cwc	Z	l	field_5223
 METHOD	cwc	(Lbji;FLcoe;)V	a	method_19330
 METHOD	cwc	(Lbji;IZ)Lcoe;	a	method_19331
-CLASS	cwd	net/minecraft/class_4240
+CLASS	cwd	net/minecraft/class_4241
 FIELD	cwd	Lpc;	c	field_20849
 FIELD	cwd	Lpc;	d	field_20850
 FIELD	cwd	Lpc;	e	field_20851
@@ -23462,13 +23462,13 @@ FIELD	cwd	Lcpc;	j	field_20856
 FIELD	cwd	Lcwd$d;	k	field_20857
 FIELD	cwd	Lcwd$b;	l	field_20858
 METHOD	cwd	(Lbjo;DDDFI)V	a	method_19332
-CLASS	cwd$a	net/minecraft/class_4240$class_4241
+CLASS	cwd$a	net/minecraft/class_4241$class_4242
 FIELD	cwd$a	Lcqw;	a	field_20859
-CLASS	cwd$b	net/minecraft/class_4240$class_4242
+CLASS	cwd$b	net/minecraft/class_4241$class_4243
 FIELD	cwd$b	Lcqw;	a	field_20860
-CLASS	cwd$c	net/minecraft/class_4240$class_4243
+CLASS	cwd$c	net/minecraft/class_4241$class_4244
 FIELD	cwd$c	Lcqw;	a	field_20861
-CLASS	cwd$d	net/minecraft/class_4240$class_4244
+CLASS	cwd$d	net/minecraft/class_4241$class_4245
 FIELD	cwd$d	I	a	field_20862
 FIELD	cwd$d	[Lcqw;	b	field_20863
 FIELD	cwd$d	I	c	field_20864
@@ -23692,7 +23692,7 @@ METHOD	cwt	()Laxy;	o	method_12432
 METHOD	cwt	()V	p	method_10174
 CLASS	cwu	net/minecraft/class_2482
 METHOD	cwu	(Laxy;Lcue;)Lcwt;	create	create
-CLASS	cwv	net/minecraft/class_4245
+CLASS	cwv	net/minecraft/class_4246
 FIELD	cwv	I	a	field_20869
 FIELD	cwv	I	b	field_20870
 FIELD	cwv	Lel;	c	field_20871
@@ -23707,7 +23707,7 @@ METHOD	cwv	(Laxy;Lel;Lel;I)Lcwv;	a	method_19346
 METHOD	cwv	(Lel;)I	a	method_19347
 METHOD	cwv	(Lel;Lbnj$a;)Lbji;	a	method_19348
 METHOD	cwv	(Layi;Lel;)I	b	method_19349
-CLASS	cwv$a	net/minecraft/class_4245$class_4246
+CLASS	cwv$a	net/minecraft/class_4246$class_4247
 FIELD	cwv$a	Lblc;	a	field_20878
 FIELD	cwv$a	Lbyw;	b	field_20879
 FIELD	cwv$a	Lcwv;	c	field_20880
@@ -23766,7 +23766,7 @@ FIELD	cxc	[F	c	field_2082
 FIELD	cxc	[F	d	field_2083
 METHOD	cxc	([FDDD)D	a	method_10189
 METHOD	cxc	(DDDDDD)Z	b	method_1496
-CLASS	cxe	net/minecraft/class_4247
+CLASS	cxe	net/minecraft/class_4248
 FIELD	cxe	Lcft;	a	field_20883
 FIELD	cxe	Ljava/util/Map;	b	field_20884
 FIELD	cxe	Ljava/util/Map;	c	field_20885
@@ -23810,7 +23810,7 @@ CLASS	cxh$a	net/minecraft/class_2890$class_3025
 METHOD	cxh$a	(FJ)V	a	method_13452
 CLASS	cxi	net/minecraft/class_3026
 FIELD	cxi	Lcft;	a	field_14976
-CLASS	cxj	net/minecraft/class_4248
+CLASS	cxj	net/minecraft/class_4249
 FIELD	cxj	Lcft;	a	field_20898
 CLASS	cxk	net/minecraft/class_3098
 FIELD	cxk	Lcft;	a	field_15290
@@ -23830,7 +23830,7 @@ METHOD	cxl	(ILcbe;F)V	a	method_12434
 METHOD	cxl	(Lcbc;)F	a	method_13454
 CLASS	cxm	net/minecraft/class_3299
 FIELD	cxm	Lcft;	a	field_16142
-CLASS	cxn	net/minecraft/class_4249
+CLASS	cxn	net/minecraft/class_4250
 FIELD	cxn	Lcft;	a	field_20899
 FIELD	cxn	Ljava/util/Map;	b	field_20900
 FIELD	cxn	Ljava/util/Map;	c	field_20901
@@ -23842,7 +23842,7 @@ FIELD	cxo	Laog;	b	field_14981
 FIELD	cxo	D	c	field_14982
 FIELD	cxo	D	d	field_14983
 FIELD	cxo	D	e	field_14984
-CLASS	cxp	net/minecraft/class_4250
+CLASS	cxp	net/minecraft/class_4251
 FIELD	cxp	Lcft;	a	field_20903
 FIELD	cxp	Ljava/util/List;	b	field_20904
 FIELD	cxp	Ljava/util/List;	c	field_20905
@@ -23887,10 +23887,10 @@ CLASS	cxy	net/minecraft/class_1632
 FIELD	cxy	Lpc;	a	field_6469
 METHOD	cxy	(Lams;)Lpc;	a	method_5736
 METHOD	cxy	(Lams;F)V	a	method_5737
-CLASS	cxz	net/minecraft/class_4251
+CLASS	cxz	net/minecraft/class_4252
 FIELD	cxz	Ljava/util/Map;	a	field_20910
 METHOD	cxz	(Lako;)Lpc;	a	method_19357
-CLASS	cy	net/minecraft/class_4252
+CLASS	cy	net/minecraft/class_4253
 FIELD	cy	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_20911
 FIELD	cy	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_20912
 FIELD	cy	Ljava/util/Collection;	c	field_20913
@@ -23905,7 +23905,7 @@ CLASS	cya	net/minecraft/class_543
 FIELD	cya	Lpc;	a	field_6470
 METHOD	cya	(Lajr;)Lpc;	a	method_5738
 METHOD	cya	(Lajr;F)F	a	method_1501
-CLASS	cyb	net/minecraft/class_4253
+CLASS	cyb	net/minecraft/class_4254
 FIELD	cyb	Lpc;	a	field_20914
 METHOD	cyb	(Lajs;)Lpc;	a	method_19362
 METHOD	cyb	(Lajs;FFF)V	a	method_19363
@@ -23918,12 +23918,12 @@ METHOD	cyd	(Lamt;)Lpc;	a	method_5740
 METHOD	cyd	(Lamt;F)V	a	method_1503
 METHOD	cyd	(Lamt;FF)I	a	method_1504
 CLASS	cye	net/minecraft/class_546
-CLASS	cyf	net/minecraft/class_4254
+CLASS	cyf	net/minecraft/class_4255
 FIELD	cyf	Lcqw;	a	field_20915
 FIELD	cyf	Lcqw;	b	field_20916
 FIELD	cyf	Lcqw;	c	field_20917
 FIELD	cyf	Lcqw;	d	field_20918
-CLASS	cyg	net/minecraft/class_4255
+CLASS	cyg	net/minecraft/class_4256
 FIELD	cyg	Lpc;	a	field_20919
 METHOD	cyg	(Laju;)Lpc;	a	method_19364
 METHOD	cyg	(Laju;F)V	a	method_19365
@@ -23932,11 +23932,11 @@ CLASS	cyh	net/minecraft/class_2894
 FIELD	cyh	Lpc;	a	field_13629
 METHOD	cyh	(Laon;)Lpc;	a	method_12442
 METHOD	cyh	(Laon;DDDFF)V	a	method_12443
-CLASS	cyi	net/minecraft/class_4256
+CLASS	cyi	net/minecraft/class_4257
 FIELD	cyi	Lpc;	a	field_20920
 FIELD	cyi	F	j	field_20921
 METHOD	cyi	(FFF)F	b	method_19367
-CLASS	cyi$1	net/minecraft/class_4256$1
+CLASS	cyi$1	net/minecraft/class_4257$1
 FIELD	cyi$1	Lcyi;	a	field_20922
 CLASS	cyj	net/minecraft/class_3100
 FIELD	cyj	Lpc;	a	field_15294
@@ -24082,7 +24082,7 @@ METHOD	cyy	(Lanc;Lcwz;DDD)Z	a	method_10218
 CLASS	cyz	net/minecraft/class_1633
 FIELD	cyz	Ljava/util/Map;	a	field_6490
 METHOD	cyz	(Lako;)Lpc;	a	method_19368
-CLASS	cz	net/minecraft/class_4257
+CLASS	cz	net/minecraft/class_4258
 FIELD	cz	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_20923
 FIELD	cz	Ljava/util/Collection;	b	field_20924
 METHOD	cz	()Lcz;	a	method_19369
@@ -24091,7 +24091,7 @@ METHOD	cz	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lcz$a
 METHOD	cz	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	cz	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	cz	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	cz$a	net/minecraft/class_4257$class_4258
+CLASS	cz$a	net/minecraft/class_4258$class_4259
 FIELD	cz$a	I	a	field_20925
 FIELD	cz$a	I	b	field_20926
 METHOD	cz$a	()Ljava/lang/String;	toString	toString
@@ -24256,7 +24256,7 @@ FIELD	czt	[Lpc;	a	field_16147
 METHOD	czt	(Lajz;)Lpc;	a	method_14693
 METHOD	czt	(Lajz;F)F	a	method_14694
 METHOD	czt	(Lajz;F)F	b	method_14695
-CLASS	czu	net/minecraft/class_4259
+CLASS	czu	net/minecraft/class_4260
 FIELD	czu	Lpc;	a	field_20937
 METHOD	czu	(Lanh;)Lpc;	a	method_19404
 METHOD	czu	(Lanh;F)V	a	method_19405
@@ -24274,7 +24274,7 @@ FIELD	czx	Lpc;	a	field_14985
 METHOD	czx	(Lakb;)Lpc;	a	method_13455
 METHOD	czx	(Lakb;DDDFF)V	a	method_13456
 METHOD	czx	(Lakb;F)V	a	method_13457
-CLASS	czy	net/minecraft/class_4260
+CLASS	czy	net/minecraft/class_4261
 FIELD	czy	Lpc;	a	field_20938
 FIELD	czy	I	j	field_20939
 FIELD	czy	Lcpm;	k	field_20940
@@ -24294,14 +24294,14 @@ FIELD	czz	Lpc;	o	field_11134
 FIELD	czz	Lpc;	p	field_11135
 METHOD	czz	(Lakd;)Lpc;	a	method_10265
 CLASS	d	net/minecraft/class_2910
-CLASS	da	net/minecraft/class_4261
+CLASS	da	net/minecraft/class_4262
 METHOD	da	()Z	a	method_19410
 METHOD	da	(Lbu;)Lcee;	a	method_19411
 METHOD	da	()Z	b	method_19412
 METHOD	da	(Lbu;)Lced;	b	method_19413
 METHOD	da	()Z	c	method_19414
 METHOD	da	(Lbu;)Lel;	c	method_19415
-CLASS	daa	net/minecraft/class_4262
+CLASS	daa	net/minecraft/class_4263
 FIELD	daa	Lpc;	a	field_20943
 METHOD	daa	(Lake;)Lpc;	a	method_19416
 METHOD	daa	(Lake;FFF)V	a	method_19417
@@ -24366,7 +24366,7 @@ FIELD	dam	Lczg;	f	field_20945
 METHOD	dam	(Laer;)Late;	e	method_10270
 CLASS	dan	net/minecraft/class_2493
 METHOD	dan	(Lapd;)Late;	a	method_10271
-CLASS	dao	net/minecraft/class_4263
+CLASS	dao	net/minecraft/class_4264
 FIELD	dao	Lpc;	a	field_20946
 FIELD	dao	Lcqd;	f	field_20947
 METHOD	dao	(DDD)D	a	method_19418
@@ -24382,17 +24382,17 @@ METHOD	daq	(Lapq;FLblc;)V	a	method_10272
 CLASS	dar	net/minecraft/class_577
 METHOD	dar	(Lamn;)Lpc;	a	method_5809
 METHOD	dar	(Lamn;DDDFF)V	a	method_1602
-CLASS	das	net/minecraft/class_4264
+CLASS	das	net/minecraft/class_4265
 FIELD	das	Lcqe;	a	field_20948
 FIELD	das	Lcqf;	j	field_20949
 METHOD	das	(Lakj;)Lpc;	a	method_19422
 METHOD	das	(Lakj;DDDFF)V	a	method_19423
 METHOD	das	(Lakj;FFF)V	a	method_19424
-CLASS	dat	net/minecraft/class_4265
+CLASS	dat	net/minecraft/class_4266
 FIELD	dat	Lpc;	a	field_20950
 METHOD	dat	(Lakk;)Lpc;	a	method_19425
 METHOD	dat	(Lakk;DDDFF)V	a	method_19426
-CLASS	dau	net/minecraft/class_4266
+CLASS	dau	net/minecraft/class_4267
 FIELD	dau	Ljava/util/Map;	a	field_20951
 METHOD	dau	(Lako;)Lpc;	a	method_19427
 CLASS	dav	net/minecraft/class_3107
@@ -24428,7 +24428,7 @@ FIELD	daz	Lpc;	a	field_6533
 FIELD	daz	Lpc;	j	field_6534
 METHOD	daz	(Lalx;)Lpc;	a	method_5813
 METHOD	daz	(Lalx;F)V	a	method_4350
-CLASS	db	net/minecraft/class_4267
+CLASS	db	net/minecraft/class_4268
 FIELD	db	D	a	field_20952
 FIELD	db	D	b	field_20953
 FIELD	db	D	c	field_20954
@@ -24506,11 +24506,11 @@ FIELD	dbk	Lcqw;	a	field_11159
 CLASS	dbl	net/minecraft/class_2500
 FIELD	dbl	Ldco;	a	field_11160
 METHOD	dbl	(Lctg;FFFFFFF)V	a	method_10287
-CLASS	dbm	net/minecraft/class_4268
+CLASS	dbm	net/minecraft/class_4269
 FIELD	dbm	Lczk;	a	field_20955
 FIELD	dbm	Lczg;	b	field_20956
 METHOD	dbm	(Lafa;Late;)V	a	method_19432
-CLASS	dbn	net/minecraft/class_4269
+CLASS	dbn	net/minecraft/class_4270
 FIELD	dbn	Lpc;	a	field_20957
 FIELD	dbn	Lcyi;	b	field_20958
 FIELD	dbn	Lcok;	c	field_20959
@@ -24570,7 +24570,7 @@ METHOD	dbw	(Laks;FFFFFFF)V	a	method_13884
 CLASS	dbx	net/minecraft/class_2506
 FIELD	dbx	Lczq;	a	field_11166
 METHOD	dbx	(Lajx;FFFFFFF)V	a	method_10293
-CLASS	dby	net/minecraft/class_4270
+CLASS	dby	net/minecraft/class_4271
 FIELD	dby	Lpc;	a	field_20963
 FIELD	dby	Lczu;	b	field_20964
 METHOD	dby	(Lanh;FFFFFFF)V	a	method_19434
@@ -24579,7 +24579,7 @@ FIELD	dbz	Lpc;	a	field_11167
 FIELD	dbz	Lczv;	b	field_11168
 FIELD	dbz	Lcpg;	c	field_11169
 METHOD	dbz	(Laka;FFFFFFF)V	a	method_10294
-CLASS	dc	net/minecraft/class_4271
+CLASS	dc	net/minecraft/class_4272
 FIELD	dc	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_20965
 FIELD	dc	Ljava/util/Collection;	b	field_20966
 METHOD	dc	()Ldc;	a	method_19435
@@ -24606,19 +24606,19 @@ CLASS	dce	net/minecraft/class_2512
 FIELD	dce	Lpc;	a	field_11176
 FIELD	dce	Ldaj;	b	field_11177
 METHOD	dce	(Lanq;FFFFFFF)V	a	method_10300
-CLASS	dcf	net/minecraft/class_4272
+CLASS	dcf	net/minecraft/class_4273
 FIELD	dcf	Lpc;	a	field_20967
 FIELD	dcf	Ldco;	b	field_20968
 FIELD	dcf	Ldcf$a;	c	field_20969
 METHOD	dcf	(Lctg;FFFFFFF)V	a	method_19438
-CLASS	dcf$a	net/minecraft/class_4272$class_4273
+CLASS	dcf$a	net/minecraft/class_4273$class_4274
 FIELD	dcf$a	Lcqw;	a	field_20970
 CLASS	dcg	net/minecraft/class_3028
 FIELD	dcg	Lpc;	a	field_14988
 FIELD	dcg	Lczk;	b	field_14989
 FIELD	dcg	Lcpy;	c	field_14990
 METHOD	dcg	(Lanr;FFFFFFF)V	a	method_13459
-CLASS	dch	net/minecraft/class_4274
+CLASS	dch	net/minecraft/class_4275
 FIELD	dch	Ldas;	a	field_20971
 FIELD	dch	Lcqe;	b	field_20972
 FIELD	dch	Lcqf;	c	field_20973
@@ -24801,7 +24801,7 @@ METHOD	dcx	()V	h	method_6988
 METHOD	dcx	()V	i	method_6989
 METHOD	dcx	()V	j	method_6990
 METHOD	dcx	()V	k	method_6991
-CLASS	dd	net/minecraft/class_4275
+CLASS	dd	net/minecraft/class_4276
 FIELD	dd	Ljava/util/Collection;	a	field_20977
 FIELD	dd	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_20978
 METHOD	dd	()Ldd;	a	method_19445
@@ -24851,7 +24851,7 @@ FIELD	ddd	Ljava/util/List;	i	field_11195
 CLASS	dde	net/minecraft/class_1637
 FIELD	dde	Ljava/util/List;	f	field_6554
 FIELD	dde	Lorg/apache/logging/log4j/Logger;	g	field_8083
-CLASS	ddf	net/minecraft/class_4276
+CLASS	ddf	net/minecraft/class_4277
 FIELD	ddf	Lpc;	l	field_20982
 FIELD	ddf	Lddb;	m	field_20983
 FIELD	ddf	Lddg;	n	field_20984
@@ -24860,7 +24860,7 @@ METHOD	ddf	()Lddf;	a	method_19454
 METHOD	ddf	()Lpc;	b	method_19455
 METHOD	ddf	()Lddb;	d	method_19456
 METHOD	ddf	()Lddf;	r	method_19457
-CLASS	ddg	net/minecraft/class_4277
+CLASS	ddg	net/minecraft/class_4278
 FIELD	ddg	Ljava/util/Set;	a	field_20986
 FIELD	ddg	Lddg$a;	b	field_20987
 FIELD	ddg	I	c	field_20988
@@ -24899,8 +24899,8 @@ METHOD	ddg	()V	f	method_19484
 METHOD	ddg	()V	g	method_19485
 METHOD	ddg	()V	h	method_19486
 METHOD	ddg	()Ljava/lang/String;	toString	toString
-CLASS	ddg$1	net/minecraft/class_4277$1
-CLASS	ddg$a	net/minecraft/class_4277$class_4278
+CLASS	ddg$1	net/minecraft/class_4278$1
+CLASS	ddg$a	net/minecraft/class_4278$class_4279
 FIELD	ddg$a	Lddg$a;	a	field_20993
 FIELD	ddg$a	Lddg$a;	b	field_20994
 FIELD	ddg$a	Lddg$a;	c	field_20995
@@ -24933,7 +24933,7 @@ METHOD	ddg$a	()I	v	method_19497
 METHOD	ddg$a	(Ljava/lang/String;)Lddg$a;	valueOf	valueOf
 METHOD	ddg$a	()[Lddg$a;	values	values
 METHOD	ddg$a	()Z	w	method_19498
-CLASS	ddg$b	net/minecraft/class_4277$class_4279
+CLASS	ddg$b	net/minecraft/class_4278$class_4280
 FIELD	ddg$b	Lddg$b;	a	field_21011
 FIELD	ddg$b	Lddg$b;	b	field_21012
 FIELD	ddg$b	Lddg$b;	c	field_21013
@@ -24944,7 +24944,7 @@ FIELD	ddg$b	[Lddg$b;	g	field_21017
 METHOD	ddg$b	()I	a	method_19499
 METHOD	ddg$b	(Ljava/lang/String;)Lddg$b;	valueOf	valueOf
 METHOD	ddg$b	()[Lddg$b;	values	values
-CLASS	ddg$c	net/minecraft/class_4277$class_4280
+CLASS	ddg$c	net/minecraft/class_4278$class_4281
 FIELD	ddg$c	Ljava/nio/channels/WritableByteChannel;	a	field_21018
 FIELD	ddg$c	Ljava/io/IOException;	b	field_21019
 METHOD	ddg$c	()V	a	method_19500
@@ -24954,7 +24954,7 @@ FIELD	ddh	I	a	field_13651
 FIELD	ddh	I	b	field_13652
 METHOD	ddh	(Ljava/io/InputStream;)Lddh$a;	a	method_19501
 CLASS	ddh$1	net/minecraft/class_2901$1
-CLASS	ddh$a	net/minecraft/class_2901$class_4281
+CLASS	ddh$a	net/minecraft/class_2901$class_4282
 FIELD	ddh$a	Z	a	field_21020
 METHOD	ddh$a	(I)V	a	method_19502
 METHOD	ddh$a	(J)I	a	method_19503
@@ -24962,14 +24962,14 @@ METHOD	ddh$a	(JI)V	a	method_19504
 METHOD	ddh$a	(JJI)I	a	method_19505
 METHOD	ddh$a	(JI)I	b	method_19506
 METHOD	ddh$a	()V	close	close
-CLASS	ddh$b	net/minecraft/class_2901$class_4282
+CLASS	ddh$b	net/minecraft/class_2901$class_4283
 FIELD	ddh$b	Ljava/nio/channels/ReadableByteChannel;	b	field_21021
 FIELD	ddh$b	J	c	field_21022
 FIELD	ddh$b	I	d	field_21023
 FIELD	ddh$b	I	e	field_21024
 FIELD	ddh$b	I	f	field_21025
 METHOD	ddh$b	(I)V	b	method_19507
-CLASS	ddh$c	net/minecraft/class_2901$class_4283
+CLASS	ddh$c	net/minecraft/class_2901$class_4284
 FIELD	ddh$c	Ljava/nio/channels/SeekableByteChannel;	b	field_21026
 CLASS	ddi	net/minecraft/class_1638
 FIELD	ddi	Lpc;	f	field_6555
@@ -25242,7 +25242,7 @@ METHOD	ddz	(Ljava/lang/String;ILjava/util/function/Predicate;)Ljava/util/Collect
 METHOD	ddz	(Ljava/lang/String;Ljava/lang/String;)Z	a	method_19537
 METHOD	ddz	(Lpc;)Ljava/io/File;	a	method_12496
 METHOD	ddz	(Ljava/lang/String;)Z	b	method_19538
-CLASS	de	net/minecraft/class_4284
+CLASS	de	net/minecraft/class_4285
 FIELD	de	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21035
 FIELD	de	Ljava/util/Collection;	b	field_21036
 FIELD	de	Z	c	field_21037
@@ -25279,7 +25279,7 @@ FIELD	dea$1	Lcom/google/common/util/concurrent/SettableFuture;	c	field_11268
 FIELD	dea$1	Ldea;	d	field_11269
 METHOD	dea$1	(Ljava/lang/Throwable;)V	onFailure	onFailure
 METHOD	dea$1	(Ljava/lang/Object;)V	onSuccess	onSuccess
-CLASS	deb	net/minecraft/class_4285
+CLASS	deb	net/minecraft/class_4286
 FIELD	deb	Lddz;	d	field_21040
 CLASS	dec	net/minecraft/class_2526
 FIELD	dec	Lpc;	a	field_11256
@@ -25330,7 +25330,7 @@ FIELD	deh$2	Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;	e	field_11271
 FIELD	deh$2	Ldeh;	f	field_8125
 CLASS	deh$a	net/minecraft/class_1885$class_1890
 METHOD	deh$a	(Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lpc;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;)V	onSkinTextureAvailable	onSkinTextureAvailable
-CLASS	dei	net/minecraft/class_4286
+CLASS	dei	net/minecraft/class_4287
 FIELD	dei	Lddg;	a	field_21044
 FIELD	dei	Lpc;	b	field_21045
 METHOD	dei	(Lddn;)V	a	method_19556
@@ -25420,7 +25420,7 @@ METHOD	dez	()Z	c	method_10375
 METHOD	dez	()Lddm;	d	method_10376
 METHOD	dez	()Lcvk;	e	method_10377
 METHOD	dez	()Lcvi;	f	method_12503
-CLASS	df	net/minecraft/class_4287
+CLASS	df	net/minecraft/class_4288
 FIELD	df	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21051
 FIELD	df	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21052
 FIELD	df	Ljava/util/Collection;	c	field_21053
@@ -25469,7 +25469,7 @@ METHOD	dfa	()[Ldfa;	values	values
 CLASS	dfb	net/minecraft/class_2530
 FIELD	dfb	Lcvk;	a	field_11295
 FIELD	dfb	Lcvi;	b	field_13658
-CLASS	dfc	net/minecraft/class_4288
+CLASS	dfc	net/minecraft/class_4289
 FIELD	dfc	Lddl;	A	field_21058
 FIELD	dfc	Ljava/util/Map;	B	field_21059
 FIELD	dfc	Ljava/util/Map;	C	field_21060
@@ -25526,7 +25526,7 @@ METHOD	dfc	(Ljava/util/Map;Lpc;Lblc;)V	b	method_19590
 METHOD	dfc	(Lpc;)V	b	method_19591
 METHOD	dfc	(Lpc;)Lcvc;	c	method_19592
 METHOD	dfc	(Lpc;)Lble;	d	method_19593
-CLASS	dfc$a	net/minecraft/class_4288$class_4289
+CLASS	dfc$a	net/minecraft/class_4289$class_4290
 CLASS	dfd	net/minecraft/class_2532
 FIELD	dfd	Ljava/util/Map;	a	field_21090
 FIELD	dfd	Lddl;	b	field_11321
@@ -25535,7 +25535,7 @@ FIELD	dfd	Ldez;	d	field_11323
 METHOD	dfd	()Ldez;	a	method_10413
 METHOD	dfd	(Ldfe;)Ldez;	a	method_19594
 METHOD	dfd	()Lcut;	b	method_10416
-CLASS	dfe	net/minecraft/class_4290
+CLASS	dfe	net/minecraft/class_4291
 FIELD	dfe	Ljava/lang/String;	c	field_21091
 METHOD	dfe	(Ljava/lang/String;)[Ljava/lang/String;	b	method_19595
 METHOD	dfe	()Ljava/lang/String;	c	method_19596
@@ -25571,7 +25571,7 @@ METHOD	dfg$a	(Lcux;)Ldfg$a;	a	method_10419
 METHOD	dfg$a	(Lddm;)Ldfg$a;	a	method_10420
 METHOD	dfg$a	(Leq;Lcux;)Ldfg$a;	a	method_10423
 METHOD	dfg$a	()Ldez;	b	method_10424
-CLASS	dfh	net/minecraft/class_4291
+CLASS	dfh	net/minecraft/class_4292
 METHOD	dfh	(Ljava/util/function/Function;Ljava/util/Set;)Ljava/util/Collection;	a	method_19598
 METHOD	dfh	(Ljava/util/function/Function;Ljava/util/function/Function;Ldfa;Z)Ldez;	a	method_19599
 METHOD	dfh	()Ljava/util/Collection;	f	method_19600
@@ -25583,7 +25583,7 @@ CLASS	dfi$a	net/minecraft/class_2536$class_2537
 FIELD	dfi$a	Ljava/util/List;	a	field_11340
 METHOD	dfi$a	()Ldez;	a	method_10428
 METHOD	dfi$a	(Ldez;I)Ldfi$a;	a	method_10427
-CLASS	dfi$b	net/minecraft/class_2536$class_4292
+CLASS	dfi$b	net/minecraft/class_2536$class_4293
 FIELD	dfi$b	Ldez;	b	field_21095
 CLASS	dfl	net/minecraft/class_1891
 FIELD	dfl	Ldft;	a	field_13678
@@ -25601,7 +25601,7 @@ FIELD	dfl	Z	l	field_21096
 FIELD	dfl	Ldgv;	m	field_13680
 CLASS	dfm	net/minecraft/class_1892
 FIELD	dfm	Z	m	field_8144
-CLASS	dfn	net/minecraft/class_4293
+CLASS	dfn	net/minecraft/class_4294
 METHOD	dfn	()V	a	method_19601
 CLASS	dfo	net/minecraft/class_2905
 FIELD	dfo	Lctj;	n	field_13681
@@ -25683,17 +25683,17 @@ METHOD	dfw$a	(Ljava/lang/String;)Ldfw$a;	valueOf	valueOf
 METHOD	dfw$a	()[Ldfw$a;	values	values
 CLASS	dfx	net/minecraft/class_1902
 METHOD	dfx	()Z	m	method_7083
-CLASS	dfy	net/minecraft/class_4294
+CLASS	dfy	net/minecraft/class_4295
 FIELD	dfy	Lctj;	a	field_21099
 FIELD	dfy	Ldgt;	b	field_21100
 FIELD	dfy	I	c	field_21101
-CLASS	dfz	net/minecraft/class_4295
-CLASS	dfz$a	net/minecraft/class_4295$class_4296
+CLASS	dfz	net/minecraft/class_4296
+CLASS	dfz$a	net/minecraft/class_4296$class_4297
 FIELD	dfz$a	Lctj;	n	field_21102
-CLASS	dfz$b	net/minecraft/class_4295$class_4297
+CLASS	dfz$b	net/minecraft/class_4296$class_4298
 FIELD	dfz$b	Lctj;	n	field_21103
 FIELD	dfz$b	I	o	field_21104
-CLASS	dg	net/minecraft/class_4298
+CLASS	dg	net/minecraft/class_4299
 FIELD	dg	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21105
 FIELD	dg	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21106
 FIELD	dg	Z	c	field_21107
@@ -25719,7 +25719,7 @@ METHOD	dgb	(Ljava/lang/Object;Ljava/lang/String;)V	a	method_14702
 METHOD	dgb	(Ljava/lang/Object;Lpc;)V	a	method_14703
 METHOD	dgb	()V	b	method_19611
 METHOD	dgb	(Ljava/lang/Object;)V	b	method_14704
-CLASS	dgb$a	net/minecraft/class_3304$class_4299
+CLASS	dgb$a	net/minecraft/class_3304$class_4300
 FIELD	dgb$a	Lcom/google/common/collect/PeekingIterator;	a	field_21110
 FIELD	dgb$a	Lcom/google/common/collect/PeekingIterator;	b	field_21111
 FIELD	dgb$a	Lit/unimi/dsi/fastutil/objects/Object2IntMap;	c	field_21112
@@ -25812,7 +25812,7 @@ METHOD	dgk	(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;	a	method_166
 METHOD	dgk	(Ljava/lang/String;)Ljava/lang/String;	b	method_1664
 METHOD	dgk	()V	interrupt	interrupt
 METHOD	dgk	()V	run	run
-CLASS	dgo	net/minecraft/class_4300
+CLASS	dgo	net/minecraft/class_4301
 FIELD	dgo	Ljava/nio/IntBuffer;	a	field_21117
 FIELD	dgo	I	b	field_21118
 FIELD	dgo	I	c	field_21119
@@ -25835,7 +25835,7 @@ METHOD	dgo	([B)Z	queueBuffer	queueBuffer
 METHOD	dgo	()V	rewind	rewind
 METHOD	dgo	(Ljavax/sound/sampled/AudioFormat;)V	setAudioFormat	setAudioFormat
 METHOD	dgo	()V	stop	stop
-CLASS	dgp	net/minecraft/class_4301
+CLASS	dgp	net/minecraft/class_4302
 FIELD	dgp	Ljava/nio/FloatBuffer;	a	field_21121
 FIELD	dgp	Ljava/nio/FloatBuffer;	b	field_21122
 FIELD	dgp	Ljava/nio/FloatBuffer;	c	field_21123
@@ -25865,7 +25865,7 @@ METHOD	dgp	(FFF)V	setListenerPosition	setListenerPosition
 METHOD	dgp	(FFF)V	setListenerVelocity	setListenerVelocity
 METHOD	dgp	(F)V	setMasterVolume	setMasterVolume
 METHOD	dgp	(Ljava/lang/String;)V	unloadSound	unloadSound
-CLASS	dgp$a	net/minecraft/class_4301$class_4302
+CLASS	dgp$a	net/minecraft/class_4302$class_4303
 CLASS	dgq	net/minecraft/class_1904
 FIELD	dgq	Ljava/util/Random;	a	field_8171
 FIELD	dgq	Lcft;	b	field_8172
@@ -25990,7 +25990,7 @@ FIELD	dgt$2	Ldgt;	c	field_8222
 METHOD	dgt$2	()Ldft;	a	method_7133
 CLASS	dgt$3	net/minecraft/class_1909$3
 FIELD	dgt$3	[I	a	field_8223
-CLASS	dgu	net/minecraft/class_4303
+CLASS	dgu	net/minecraft/class_4304
 FIELD	dgu	Ldgo;	a	field_21134
 FIELD	dgu	Ljava/nio/IntBuffer;	b	field_21135
 FIELD	dgu	Ljava/nio/FloatBuffer;	c	field_21136
@@ -26032,7 +26032,7 @@ FIELD	dgz	Ldhe;	c	field_16196
 FIELD	dgz	Lcic;	d	field_16197
 FIELD	dgz	I	e	field_16198
 METHOD	dgz	(Lctj;Lwz;)Z	a	method_19635
-CLASS	dh	net/minecraft/class_4304
+CLASS	dh	net/minecraft/class_4305
 FIELD	dh	Ldg;	a	field_21139
 FIELD	dh	Ldg;	b	field_21140
 FIELD	dh	Ldg;	c	field_21141
@@ -26137,7 +26137,7 @@ METHOD	dhi	(Ldhi;)V	c	method_19655
 METHOD	dhi	(Ljava/lang/Object;)Z	equals	equals
 METHOD	dhi	()I	hashCode	hashCode
 METHOD	dhi	()Ljava/lang/String;	toString	toString
-CLASS	dhj	net/minecraft/class_4305
+CLASS	dhj	net/minecraft/class_4306
 FIELD	dhj	[F	a	field_21143
 METHOD	dhj	()F	a	method_19656
 METHOD	dhj	(Ldhj;)V	a	method_19657
@@ -26152,7 +26152,7 @@ CLASS	dhk	net/minecraft/class_2547
 FIELD	dhk	D	a	field_11392
 FIELD	dhk	D	b	field_11393
 FIELD	dhk	D	c	field_11394
-CLASS	dhl	net/minecraft/class_4306
+CLASS	dhl	net/minecraft/class_4307
 FIELD	dhl	[F	a	field_21144
 METHOD	dhl	()F	a	method_19662
 METHOD	dhl	(F)V	a	method_19663
@@ -26167,7 +26167,7 @@ METHOD	dhl	(Ldhl;)V	c	method_19671
 METHOD	dhl	()V	d	method_19672
 METHOD	dhl	(Ljava/lang/Object;)Z	equals	equals
 METHOD	dhl	()I	hashCode	hashCode
-CLASS	dhm	net/minecraft/class_4307
+CLASS	dhm	net/minecraft/class_4308
 FIELD	dhm	[F	a	field_21145
 METHOD	dhm	()F	a	method_19673
 METHOD	dhm	(FFFF)V	a	method_19674
@@ -26312,7 +26312,7 @@ FIELD	dhq$a	Ldhq$a;	c	field_13713
 FIELD	dhq$a	[Ldhq$a;	d	field_13714
 METHOD	dhq$a	(Ljava/lang/String;)Ldhq$a;	valueOf	valueOf
 METHOD	dhq$a	()[Ldhq$a;	values	values
-CLASS	dj	net/minecraft/class_4308
+CLASS	dj	net/minecraft/class_4309
 FIELD	dj	Ljava/util/Collection;	a	field_21151
 FIELD	dj	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21152
 FIELD	dj	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_21153
@@ -26325,9 +26325,9 @@ METHOD	dj	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	b	method_19696
 METHOD	dj	(Lpc;Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/Collection;	b	method_19697
 METHOD	dj	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	dj	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	dj$a	net/minecraft/class_4308$class_4309
+CLASS	dj$a	net/minecraft/class_4309$class_4310
 METHOD	dj$a	(Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/Collection;	create	create
-CLASS	dk	net/minecraft/class_4310
+CLASS	dk	net/minecraft/class_4311
 FIELD	dk	Ljava/util/Collection;	a	field_21154
 METHOD	dk	()Ldk;	a	method_19698
 METHOD	dk	(Lcom/mojang/brigadier/StringReader;)Ldl;	a	method_19699
@@ -26335,7 +26335,7 @@ METHOD	dk	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ldl;	
 METHOD	dk	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	dk	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	dk	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	dl	net/minecraft/class_4311
+CLASS	dl	net/minecraft/class_4312
 FIELD	dl	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	a	field_21155
 FIELD	dl	Lata;	b	field_21156
 FIELD	dl	Lgy;	c	field_21157
@@ -26345,7 +26345,7 @@ METHOD	dl	(Late;)Z	a	method_19703
 METHOD	dl	(Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	a	method_19704
 METHOD	dl	()Ljava/lang/String;	c	method_19705
 METHOD	dl	(Ljava/lang/Object;)Z	test	test
-CLASS	dm	net/minecraft/class_4312
+CLASS	dm	net/minecraft/class_4313
 FIELD	dm	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21158
 FIELD	dm	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21159
 FIELD	dm	Ljava/util/function/Function;	c	field_21160
@@ -26369,7 +26369,7 @@ METHOD	dm	()V	e	method_19714
 METHOD	dm	()V	f	method_19715
 METHOD	dm	()V	g	method_19716
 METHOD	dm	()Ldm;	h	method_19717
-CLASS	dn	net/minecraft/class_4313
+CLASS	dn	net/minecraft/class_4314
 FIELD	dn	Ljava/util/Collection;	a	field_21169
 FIELD	dn	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21170
 METHOD	dn	()Ldn;	a	method_19718
@@ -26381,19 +26381,19 @@ METHOD	dn	(Lpc;Ldm;Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/func
 METHOD	dn	()Ljava/util/Collection;	getExamples	getExamples
 METHOD	dn	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	listSuggestions	listSuggestions
 METHOD	dn	(Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;	parse	parse
-CLASS	dn$a	net/minecraft/class_4313$class_4314
+CLASS	dn$a	net/minecraft/class_4314$class_4315
 FIELD	dn$a	Lata;	a	field_21171
 FIELD	dn$a	Lgy;	b	field_21172
 METHOD	dn$a	(Late;)Z	a	method_19724
 METHOD	dn$a	(Ljava/lang/Object;)Z	test	test
-CLASS	dn$b	net/minecraft/class_4313$class_4315
+CLASS	dn$b	net/minecraft/class_4314$class_4316
 METHOD	dn$b	(Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/function/Predicate;	create	create
-CLASS	dn$c	net/minecraft/class_4313$class_4316
+CLASS	dn$c	net/minecraft/class_4314$class_4317
 FIELD	dn$c	Lwz;	a	field_21173
 FIELD	dn$c	Lgy;	b	field_21174
 METHOD	dn$c	(Late;)Z	a	method_19725
 METHOD	dn$c	(Ljava/lang/Object;)Z	test	test
-CLASS	dr	net/minecraft/class_4317
+CLASS	dr	net/minecraft/class_4318
 FIELD	dr	I	a	field_21175
 FIELD	dr	Z	b	field_21176
 FIELD	dr	Z	c	field_21177
@@ -26422,7 +26422,7 @@ METHOD	dr	(Lbu;)Ltf;	c	method_19737
 METHOD	dr	()Z	d	method_19738
 METHOD	dr	(Lbu;)Ljava/util/List;	d	method_19739
 METHOD	dr	(Lbu;)V	e	method_19740
-CLASS	ds	net/minecraft/class_4318
+CLASS	ds	net/minecraft/class_4319
 FIELD	ds	Ljava/util/function/Predicate;	A	field_21188
 FIELD	ds	Ljava/util/function/BiConsumer;	B	field_21189
 FIELD	ds	Z	C	field_21190
@@ -26554,7 +26554,7 @@ METHOD	ds	()Z	w	method_19822
 METHOD	ds	()Z	x	method_19823
 METHOD	ds	()Z	y	method_19824
 METHOD	ds	()Z	z	method_19825
-CLASS	dt	net/minecraft/class_4319
+CLASS	dt	net/minecraft/class_4320
 FIELD	dt	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_21234
 FIELD	dt	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21235
 FIELD	dt	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_21236
@@ -26627,18 +26627,18 @@ METHOD	dt	(Lds;)Z	w	method_19885
 METHOD	dt	(Lds;)V	x	method_19886
 METHOD	dt	(Lds;)Z	y	method_19887
 METHOD	dt	(Lds;)V	z	method_19888
-CLASS	dt$1	net/minecraft/class_4319$1
-CLASS	dt$a	net/minecraft/class_4319$class_4320
+CLASS	dt$1	net/minecraft/class_4320$1
+CLASS	dt$a	net/minecraft/class_4320$class_4321
 METHOD	dt$a	(Lds;)V	handle	handle
-CLASS	dt$b	net/minecraft/class_4319$class_4321
+CLASS	dt$b	net/minecraft/class_4320$class_4322
 FIELD	dt$b	Ldt$a;	a	field_21243
 FIELD	dt$b	Ljava/util/function/Predicate;	b	field_21244
 FIELD	dt$b	Lij;	c	field_21245
-CLASS	dy	net/minecraft/class_4322
+CLASS	dy	net/minecraft/class_4323
 METHOD	dy	(Lcom/mojang/brigadier/arguments/ArgumentType;Lcom/google/gson/JsonObject;)V	a	method_19889
 METHOD	dy	(Lcom/mojang/brigadier/arguments/ArgumentType;Lhy;)V	a	method_19890
 METHOD	dy	(Lhy;)Lcom/mojang/brigadier/arguments/ArgumentType;	b	method_19891
-CLASS	dz	net/minecraft/class_4323
+CLASS	dz	net/minecraft/class_4324
 FIELD	dz	Lorg/apache/logging/log4j/Logger;	a	field_21246
 FIELD	dz	Ljava/util/Map;	b	field_21247
 FIELD	dz	Ljava/util/Map;	c	field_21248
@@ -26650,17 +26650,17 @@ METHOD	dz	(Lhy;)Lcom/mojang/brigadier/arguments/ArgumentType;	a	method_19896
 METHOD	dz	(Lhy;Lcom/mojang/brigadier/arguments/ArgumentType;)V	a	method_19897
 METHOD	dz	(Lpc;)Ldz$a;	a	method_19898
 METHOD	dz	(Lpc;Ljava/lang/Class;Ldy;)V	a	method_19899
-CLASS	dz$1	net/minecraft/class_4323$1
-CLASS	dz$a	net/minecraft/class_4323$class_4324
+CLASS	dz$1	net/minecraft/class_4324$1
+CLASS	dz$a	net/minecraft/class_4324$class_4325
 FIELD	dz$a	Ljava/lang/Class;	a	field_21249
 FIELD	dz$a	Ldy;	b	field_21250
 FIELD	dz$a	Lpc;	c	field_21251
-CLASS	e	net/minecraft/class_4325
+CLASS	e	net/minecraft/class_4326
 FIELD	e	Lorg/apache/logging/log4j/Logger;	a	field_21252
 METHOD	e	(Ljava/lang/Thread;Ljava/lang/Throwable;)V	uncaughtException	uncaughtException
-CLASS	ea	net/minecraft/class_4326
+CLASS	ea	net/minecraft/class_4327
 FIELD	ea	Ljava/util/function/Supplier;	a	field_21253
-CLASS	eb	net/minecraft/class_4327
+CLASS	eb	net/minecraft/class_4328
 FIELD	eb	Lcom/mojang/brigadier/suggestion/SuggestionProvider;	a	field_21254
 FIELD	eb	Lcom/mojang/brigadier/suggestion/SuggestionProvider;	b	field_21255
 FIELD	eb	Lcom/mojang/brigadier/suggestion/SuggestionProvider;	c	field_21256
@@ -26676,35 +26676,35 @@ METHOD	eb	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/su
 METHOD	eb	(Lcom/mojang/brigadier/suggestion/SuggestionProvider;)Lcom/mojang/brigadier/suggestion/SuggestionProvider;	b	method_19906
 METHOD	eb	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	c	method_19907
 METHOD	eb	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	d	method_19908
-CLASS	eb$a	net/minecraft/class_4327$class_4328
+CLASS	eb$a	net/minecraft/class_4328$class_4329
 FIELD	eb$a	Lcom/mojang/brigadier/suggestion/SuggestionProvider;	a	field_21260
 FIELD	eb$a	Lpc;	b	field_21261
 METHOD	eb$a	(Leb$a;)Lpc;	a	method_19909
 METHOD	eb$a	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	getSuggestions	getSuggestions
-CLASS	ec	net/minecraft/class_4329
+CLASS	ec	net/minecraft/class_4330
 METHOD	ec	()V	a	method_19910
 METHOD	ec	(B)Z	a	method_19911
 METHOD	ec	(ZZ)B	a	method_19912
 METHOD	ec	(B)Z	b	method_19913
-CLASS	ed	net/minecraft/class_4330
+CLASS	ed	net/minecraft/class_4331
 METHOD	ed	(Lcom/mojang/brigadier/arguments/DoubleArgumentType;Lcom/google/gson/JsonObject;)V	a	method_19914
 METHOD	ed	(Lcom/mojang/brigadier/arguments/DoubleArgumentType;Lhy;)V	a	method_19915
 METHOD	ed	(Lhy;)Lcom/mojang/brigadier/arguments/DoubleArgumentType;	a	method_19916
-CLASS	ee	net/minecraft/class_4331
+CLASS	ee	net/minecraft/class_4332
 METHOD	ee	(Lcom/mojang/brigadier/arguments/FloatArgumentType;Lcom/google/gson/JsonObject;)V	a	method_19917
 METHOD	ee	(Lcom/mojang/brigadier/arguments/FloatArgumentType;Lhy;)V	a	method_19918
 METHOD	ee	(Lhy;)Lcom/mojang/brigadier/arguments/FloatArgumentType;	a	method_19919
-CLASS	ef	net/minecraft/class_4332
+CLASS	ef	net/minecraft/class_4333
 METHOD	ef	(Lcom/mojang/brigadier/arguments/IntegerArgumentType;Lcom/google/gson/JsonObject;)V	a	method_19920
 METHOD	ef	(Lcom/mojang/brigadier/arguments/IntegerArgumentType;Lhy;)V	a	method_19921
 METHOD	ef	(Lhy;)Lcom/mojang/brigadier/arguments/IntegerArgumentType;	a	method_19922
-CLASS	eg	net/minecraft/class_4333
+CLASS	eg	net/minecraft/class_4334
 METHOD	eg	(Lcom/mojang/brigadier/arguments/StringArgumentType;Lcom/google/gson/JsonObject;)V	a	method_19923
 METHOD	eg	(Lcom/mojang/brigadier/arguments/StringArgumentType;Lhy;)V	a	method_19924
 METHOD	eg	(Lhy;)Lcom/mojang/brigadier/arguments/StringArgumentType;	a	method_19925
-CLASS	eg$1	net/minecraft/class_4333$1
+CLASS	eg$1	net/minecraft/class_4334$1
 FIELD	eg$1	[I	a	field_21262
-CLASS	ej	net/minecraft/class_4334
+CLASS	ej	net/minecraft/class_4335
 FIELD	ej	Lej;	a	field_21263
 FIELD	ej	Lej;	b	field_21264
 FIELD	ej	Lej;	c	field_21265
@@ -26717,9 +26717,9 @@ METHOD	ej	(Leq$a;)Leq$a;	a	method_19928
 METHOD	ej	(Leq$a;Leq$a;)Lej;	a	method_19929
 METHOD	ej	(Ljava/lang/String;)Lej;	valueOf	valueOf
 METHOD	ej	()[Lej;	values	values
-CLASS	ej$1	net/minecraft/class_4334$1
-CLASS	ej$2	net/minecraft/class_4334$2
-CLASS	ej$3	net/minecraft/class_4334$3
+CLASS	ej$1	net/minecraft/class_4335$1
+CLASS	ej$2	net/minecraft/class_4335$2
+CLASS	ej$3	net/minecraft/class_4335$3
 CLASS	el	net/minecraft/class_2552
 FIELD	el	Lel;	a	field_11426
 FIELD	el	Lorg/apache/logging/log4j/Logger;	b	field_13715
@@ -26930,7 +26930,7 @@ METHOD	eq$c	()Ljava/util/Iterator;	iterator	iterator
 METHOD	eq$c	(Ljava/lang/Object;)Z	test	test
 METHOD	eq$c	(Ljava/lang/String;)Leq$c;	valueOf	valueOf
 METHOD	eq$c	()[Leq$c;	values	values
-CLASS	er	net/minecraft/class_4335
+CLASS	er	net/minecraft/class_4336
 FIELD	er	Ler;	a	field_21293
 FIELD	er	Ler;	b	field_21294
 FIELD	er	Ler;	c	field_21295
@@ -26991,7 +26991,7 @@ METHOD	ez	(I)Ljava/lang/Object;	get	get
 METHOD	ez	(I)Ljava/lang/Object;	remove	remove
 METHOD	ez	(ILjava/lang/Object;)Ljava/lang/Object;	set	set
 METHOD	ez	()I	size	size
-CLASS	f	net/minecraft/class_4336
+CLASS	f	net/minecraft/class_4337
 FIELD	f	Lorg/apache/logging/log4j/Logger;	a	field_21316
 METHOD	f	(Ljava/lang/Thread;Ljava/lang/Throwable;)V	uncaughtException	uncaughtException
 CLASS	fa	net/minecraft/class_1364
@@ -27067,15 +27067,15 @@ METHOD	ff	()I	o	method_10572
 METHOD	ff	()I	p	method_10573
 METHOD	ff	()I	q	method_10574
 METHOD	ff	()Ljava/lang/String;	toString	toString
-CLASS	fh	net/minecraft/class_4337
+CLASS	fh	net/minecraft/class_4338
 FIELD	fh	Lfk$a;	a	field_21336
 FIELD	fh	Lfl;	b	field_21337
 FIELD	fh	Lblc;	c	field_21338
 METHOD	fh	()Lblc;	c	method_19966
-CLASS	fh$1	net/minecraft/class_4337$1
+CLASS	fh$1	net/minecraft/class_4338$1
 METHOD	fh$1	(Lfl;Lcom/mojang/brigadier/StringReader;)Lfh;	a	method_19967
 METHOD	fh$1	(Lfl;Lhy;)Lfh;	a	method_19968
-CLASS	fi	net/minecraft/class_4338
+CLASS	fi	net/minecraft/class_4339
 FIELD	fi	Lfi;	a	field_21339
 FIELD	fi	Lfk$a;	b	field_21340
 FIELD	fi	F	c	field_21341
@@ -27086,22 +27086,22 @@ METHOD	fi	()F	c	method_19969
 METHOD	fi	()F	d	method_19970
 METHOD	fi	()F	e	method_19971
 METHOD	fi	()F	f	method_19972
-CLASS	fi$1	net/minecraft/class_4338$1
+CLASS	fi$1	net/minecraft/class_4339$1
 METHOD	fi$1	(Lfl;Lcom/mojang/brigadier/StringReader;)Lfi;	a	method_19973
 METHOD	fi$1	(Lfl;Lhy;)Lfi;	a	method_19974
-CLASS	fj	net/minecraft/class_4339
+CLASS	fj	net/minecraft/class_4340
 FIELD	fj	Lfk$a;	a	field_21345
 FIELD	fj	Lfl;	b	field_21346
 FIELD	fj	Late;	c	field_21347
 METHOD	fj	()Late;	c	method_19975
-CLASS	fj$1	net/minecraft/class_4339$1
+CLASS	fj$1	net/minecraft/class_4340$1
 METHOD	fj$1	(Lfl;Lcom/mojang/brigadier/StringReader;)Lfj;	a	method_19976
 METHOD	fj$1	(Lfl;Lhy;)Lfj;	a	method_19977
-CLASS	fk	net/minecraft/class_4340
+CLASS	fk	net/minecraft/class_4341
 METHOD	fk	()Ljava/lang/String;	a	method_19978
 METHOD	fk	(Lhy;)V	a	method_19979
 METHOD	fk	()Lfl;	b	method_19980
-CLASS	fk$a	net/minecraft/class_4340$class_4341
+CLASS	fk$a	net/minecraft/class_4341$class_4342
 METHOD	fk$a	(Lfl;Lcom/mojang/brigadier/StringReader;)Lfk;	b	method_19981
 METHOD	fk$a	(Lfl;Lhy;)Lfk;	b	method_19982
 CLASS	fl	net/minecraft/class_2562
@@ -27114,7 +27114,7 @@ METHOD	fl	()V	c	method_19985
 METHOD	fl	()Lpc;	d	method_19986
 METHOD	fl	()Z	e	method_10561
 METHOD	fl	()Lfk$a;	f	method_19987
-CLASS	fm	net/minecraft/class_4342
+CLASS	fm	net/minecraft/class_4343
 FIELD	fm	Lfn;	A	field_21351
 FIELD	fm	Lfn;	B	field_21352
 FIELD	fm	Lfl;	C	field_21353
@@ -27166,12 +27166,12 @@ FIELD	fm	Lfn;	x	field_21398
 FIELD	fm	Lfn;	y	field_21399
 FIELD	fm	Lfn;	z	field_21400
 METHOD	fm	(Ljava/lang/String;)Lfl;	a	method_19988
-CLASS	fn	net/minecraft/class_4343
+CLASS	fn	net/minecraft/class_4344
 FIELD	fn	Lfk$a;	a	field_21401
-CLASS	fn$1	net/minecraft/class_4343$1
+CLASS	fn$1	net/minecraft/class_4344$1
 METHOD	fn$1	(Lfl;Lcom/mojang/brigadier/StringReader;)Lfn;	a	method_19989
 METHOD	fn$1	(Lfl;Lhy;)Lfn;	a	method_19990
-CLASS	fp	net/minecraft/class_4344
+CLASS	fp	net/minecraft/class_4345
 FIELD	fp	Lorg/apache/logging/log4j/Logger;	a	field_21402
 FIELD	fp	Ljava/util/Collection;	b	field_21403
 FIELD	fp	Ljava/nio/file/Path;	c	field_21404
@@ -27180,11 +27180,11 @@ METHOD	fp	()Ljava/util/Collection;	a	method_19991
 METHOD	fp	(Lfq;)V	a	method_19992
 METHOD	fp	()Ljava/nio/file/Path;	b	method_19993
 METHOD	fp	()V	c	method_19994
-CLASS	fq	net/minecraft/class_4345
+CLASS	fq	net/minecraft/class_4346
 FIELD	fq	Lcom/google/common/hash/HashFunction;	a	field_21406
 METHOD	fq	()Ljava/lang/String;	a	method_19995
 METHOD	fq	(Lfr;)V	a	method_19996
-CLASS	fr	net/minecraft/class_4346
+CLASS	fr	net/minecraft/class_4347
 FIELD	fr	Lorg/apache/logging/log4j/Logger;	a	field_21407
 FIELD	fr	Ljava/nio/file/Path;	b	field_21408
 FIELD	fr	Ljava/nio/file/Path;	c	field_21409
@@ -27202,21 +27202,21 @@ METHOD	fr	()Ljava/util/stream/Stream;	c	method_20004
 METHOD	fr	(Ljava/nio/file/Path;)Z	c	method_20005
 METHOD	fr	(Ljava/nio/file/Path;)V	d	method_20006
 METHOD	fr	(Ljava/nio/file/Path;)V	e	method_20007
-CLASS	fs	net/minecraft/class_4347
+CLASS	fs	net/minecraft/class_4348
 FIELD	fs	Lorg/apache/logging/log4j/Logger;	b	field_21413
 FIELD	fs	Lcom/google/gson/Gson;	c	field_21414
 FIELD	fs	Lfp;	d	field_21415
 FIELD	fs	Ljava/util/List;	e	field_21416
 METHOD	fs	(Lfr;Lcom/google/gson/JsonObject;Ljava/nio/file/Path;)V	a	method_20008
 METHOD	fs	(Ljava/util/Set;Lfr;Ljava/nio/file/Path;Ll;)V	a	method_20009
-CLASS	ft	net/minecraft/class_4348
+CLASS	ft	net/minecraft/class_4349
 FIELD	ft	[Layu;	a	field_21417
 FIELD	ft	[Laev;	b	field_21418
 METHOD	ft	(Ljava/util/function/Consumer;)V	a	method_20010
 METHOD	ft	(Ll$a;)Ll$a;	a	method_20011
 METHOD	ft	(Ljava/lang/Object;)V	accept	accept
 METHOD	ft	(Ll$a;)Ll$a;	b	method_20012
-CLASS	fu	net/minecraft/class_4349
+CLASS	fu	net/minecraft/class_4350
 FIELD	fu	[Laev;	a	field_21419
 FIELD	fu	[Lata;	b	field_21420
 FIELD	fu	[Lata;	c	field_21421
@@ -27227,27 +27227,27 @@ METHOD	fu	(Ljava/lang/Object;)V	accept	accept
 METHOD	fu	(Ll$a;)Ll$a;	b	method_20015
 METHOD	fu	(Ll$a;)Ll$a;	c	method_20016
 METHOD	fu	(Ll$a;)Ll$a;	d	method_20017
-CLASS	fv	net/minecraft/class_4350
+CLASS	fv	net/minecraft/class_4351
 METHOD	fv	(Ljava/util/function/Consumer;)V	a	method_20018
 METHOD	fv	(Ljava/lang/Object;)V	accept	accept
-CLASS	fw	net/minecraft/class_4351
+CLASS	fw	net/minecraft/class_4352
 METHOD	fw	(Ljava/util/function/Consumer;)V	a	method_20019
 METHOD	fw	(Ljava/lang/Object;)V	accept	accept
-CLASS	fx	net/minecraft/class_4352
+CLASS	fx	net/minecraft/class_4353
 METHOD	fx	(Ljava/util/function/Consumer;)V	a	method_20020
 METHOD	fx	(Ljava/lang/Object;)V	accept	accept
-CLASS	fz	net/minecraft/class_4353
+CLASS	fz	net/minecraft/class_4354
 FIELD	fz	Lfp;	b	field_21423
-CLASS	ga	net/minecraft/class_4354
+CLASS	ga	net/minecraft/class_4355
 FIELD	ga	Lfp;	b	field_21424
-CLASS	gb	net/minecraft/class_4355
+CLASS	gb	net/minecraft/class_4356
 FIELD	gb	Lfp;	b	field_21425
-CLASS	ge	net/minecraft/class_4356
+CLASS	ge	net/minecraft/class_4357
 METHOD	ge	()Lcom/google/gson/JsonObject;	a	method_20021
 METHOD	ge	()Lpc;	b	method_20022
 METHOD	ge	()Lcom/google/gson/JsonObject;	c	method_20023
 METHOD	ge	()Lpc;	d	method_20024
-CLASS	gf	net/minecraft/class_4357
+CLASS	gf	net/minecraft/class_4358
 FIELD	gf	Lorg/apache/logging/log4j/Logger;	b	field_21426
 FIELD	gf	Lcom/google/gson/Gson;	c	field_21427
 FIELD	gf	Lfp;	d	field_21428
@@ -27260,7 +27260,7 @@ METHOD	gf	(Ljava/util/function/Consumer;)V	a	method_20030
 METHOD	gf	(Lwz;)Lat$b;	a	method_20031
 METHOD	gf	([Lav;)Lat$b;	a	method_20032
 METHOD	gf	(Lfr;Lcom/google/gson/JsonObject;Ljava/nio/file/Path;)V	b	method_20033
-CLASS	gg	net/minecraft/class_4358
+CLASS	gg	net/minecraft/class_4359
 FIELD	gg	Lorg/apache/logging/log4j/Logger;	a	field_21429
 FIELD	gg	Lata;	b	field_21430
 FIELD	gg	I	c	field_21431
@@ -27280,7 +27280,7 @@ METHOD	gg	(Ljava/util/function/Consumer;Ljava/lang/String;)V	a	method_20042
 METHOD	gg	(Ljava/util/function/Consumer;Lpc;)V	a	method_20043
 METHOD	gg	(Lpc;)V	a	method_20044
 METHOD	gg	(Ljava/lang/String;)Lgg;	b	method_20045
-CLASS	gg$a	net/minecraft/class_4358$class_4359
+CLASS	gg$a	net/minecraft/class_4359$class_4360
 FIELD	gg$a	Lgg;	a	field_21436
 FIELD	gg$a	Lpc;	b	field_21437
 FIELD	gg$a	Lata;	c	field_21438
@@ -27290,7 +27290,7 @@ FIELD	gg$a	Ljava/util/List;	f	field_21441
 FIELD	gg$a	Ljava/util/Map;	g	field_21442
 FIELD	gg$a	Ll$a;	h	field_21443
 FIELD	gg$a	Lpc;	i	field_21444
-CLASS	gh	net/minecraft/class_4360
+CLASS	gh	net/minecraft/class_4361
 FIELD	gh	Lorg/apache/logging/log4j/Logger;	a	field_21445
 FIELD	gh	Lata;	b	field_21446
 FIELD	gh	I	c	field_21447
@@ -27310,7 +27310,7 @@ METHOD	gh	(Lpc;)V	a	method_20055
 METHOD	gh	(Lwz;)Lgh;	a	method_20056
 METHOD	gh	(Laxx;)Lgh;	b	method_20057
 METHOD	gh	(Laxx;I)Lgh;	b	method_20058
-CLASS	gh$a	net/minecraft/class_4360$class_4361
+CLASS	gh$a	net/minecraft/class_4361$class_4362
 FIELD	gh$a	Lpc;	a	field_21451
 FIELD	gh$a	Lata;	b	field_21452
 FIELD	gh$a	I	c	field_21453
@@ -27318,7 +27318,7 @@ FIELD	gh$a	Ljava/lang/String;	d	field_21454
 FIELD	gh$a	Ljava/util/List;	e	field_21455
 FIELD	gh$a	Ll$a;	f	field_21456
 FIELD	gh$a	Lpc;	g	field_21457
-CLASS	gi	net/minecraft/class_4362
+CLASS	gi	net/minecraft/class_4363
 FIELD	gi	Lorg/apache/logging/log4j/Logger;	a	field_21458
 FIELD	gi	Lata;	b	field_21459
 FIELD	gi	Lavh;	c	field_21460
@@ -27332,7 +27332,7 @@ METHOD	gi	(Ljava/util/function/Consumer;)V	a	method_20061
 METHOD	gi	(Ljava/util/function/Consumer;Ljava/lang/String;)V	a	method_20062
 METHOD	gi	(Ljava/util/function/Consumer;Lpc;)V	a	method_20063
 METHOD	gi	(Lpc;)V	a	method_20064
-CLASS	gi$a	net/minecraft/class_4362$class_4363
+CLASS	gi$a	net/minecraft/class_4363$class_4364
 FIELD	gi$a	Lpc;	a	field_21465
 FIELD	gi$a	Ljava/lang/String;	b	field_21466
 FIELD	gi$a	Lavh;	c	field_21467
@@ -27341,35 +27341,35 @@ FIELD	gi$a	F	e	field_21469
 FIELD	gi$a	I	f	field_21470
 FIELD	gi$a	Ll$a;	g	field_21471
 FIELD	gi$a	Lpc;	h	field_21472
-CLASS	gj	net/minecraft/class_4364
+CLASS	gj	net/minecraft/class_4365
 FIELD	gj	Lavn$a;	a	field_21473
 METHOD	gj	(Lavn$a;)Lgj;	a	method_20065
 METHOD	gj	(Lgj;)Lavn$a;	a	method_20066
 METHOD	gj	(Ljava/util/function/Consumer;Ljava/lang/String;)V	a	method_20067
-CLASS	gj$1	net/minecraft/class_4364$1
+CLASS	gj$1	net/minecraft/class_4365$1
 FIELD	gj$1	Ljava/lang/String;	a	field_21474
 FIELD	gj$1	Lgj;	b	field_21475
-CLASS	gl	net/minecraft/class_4365
+CLASS	gl	net/minecraft/class_4366
 FIELD	gl	Lorg/apache/logging/log4j/Logger;	b	field_21476
 FIELD	gl	Lfp;	c	field_21477
 METHOD	gl	(Ljava/nio/file/Path;)Z	a	method_20068
 METHOD	gl	(Ljava/nio/file/Path;Ljava/lang/String;Ljava/nio/file/Path;)V	a	method_20069
 METHOD	gl	(Ljava/nio/file/Path;Ljava/nio/file/Path;)Ljava/lang/String;	a	method_20070
 METHOD	gl	(Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;)V	a	method_20071
-CLASS	gm	net/minecraft/class_4366
+CLASS	gm	net/minecraft/class_4367
 FIELD	gm	Lorg/apache/logging/log4j/Logger;	b	field_21478
 FIELD	gm	Lfp;	c	field_21479
 METHOD	gm	(Lfr;Ljava/nio/file/Path;Ljava/lang/String;Ljava/nio/file/Path;)V	a	method_20072
 METHOD	gm	(Lfr;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/nio/file/Path;)V	a	method_20073
 METHOD	gm	(Ljava/nio/file/Path;)Z	a	method_20074
 METHOD	gm	(Ljava/nio/file/Path;Ljava/nio/file/Path;)Ljava/lang/String;	a	method_20075
-CLASS	go	net/minecraft/class_4367
-CLASS	gp	net/minecraft/class_4368
-CLASS	gq	net/minecraft/class_4369
+CLASS	go	net/minecraft/class_4368
+CLASS	gp	net/minecraft/class_4369
+CLASS	gq	net/minecraft/class_4370
 FIELD	gq	Lorg/apache/logging/log4j/Logger;	e	field_21480
 METHOD	gq	(Lwz$b;)Lwz$b;	a	method_20076
 METHOD	gq	(Lwz;Lwz;)V	a	method_20077
-CLASS	gr	net/minecraft/class_4370
+CLASS	gr	net/minecraft/class_4371
 FIELD	gr	Lfp;	b	field_21481
 FIELD	gr	Lfc;	c	field_21482
 FIELD	gr	Ljava/util/Map;	d	field_21483
@@ -27406,7 +27406,7 @@ FIELD	gw	B	f	field_858
 METHOD	gw	()Lgw;	c	method_13469
 METHOD	gw	(Ljava/lang/Object;)Z	equals	equals
 METHOD	gw	()I	hashCode	hashCode
-CLASS	gx	net/minecraft/class_4371
+CLASS	gx	net/minecraft/class_4372
 METHOD	gx	(ILho;)V	a	method_20086
 METHOD	gx	(I)V	b	method_20087
 METHOD	gx	(ILho;)Lho;	b	method_20088
@@ -27553,7 +27553,7 @@ METHOD	hi	(Ljava/io/DataInputStream;)Lgy;	a	method_7363
 METHOD	hi	(Ljava/io/File;)Lgy;	a	method_7364
 METHOD	hi	(Ljava/io/InputStream;)Lgy;	a	method_1350
 METHOD	hi	(Lgy;Ljava/io/File;)V	b	method_1352
-CLASS	hj	net/minecraft/class_4372
+CLASS	hj	net/minecraft/class_4373
 FIELD	hj	Lhj;	a	field_21487
 METHOD	hj	()Lho;	a	method_20103
 METHOD	hj	(B)Lho;	a	method_20104
@@ -27652,7 +27652,7 @@ METHOD	hn	(Ljava/lang/String;Z)Ljava/lang/String;	a	method_20144
 METHOD	hn	()Lhn;	c	method_13483
 METHOD	hn	(Ljava/lang/Object;)Z	equals	equals
 METHOD	hn	()I	hashCode	hashCode
-CLASS	ho	net/minecraft/class_4373
+CLASS	ho	net/minecraft/class_4374
 FIELD	ho	[Ljava/lang/String;	a	field_21488
 FIELD	ho	La;	b	field_21489
 FIELD	ho	La;	c	field_21490
@@ -28044,7 +28044,7 @@ FIELD	hz	Lorg/apache/logging/log4j/Logger;	a	field_8466
 FIELD	hz	Lorg/apache/logging/log4j/Marker;	b	field_8467
 FIELD	hz	Liw;	c	field_8468
 METHOD	hz	(Lio/netty/channel/ChannelHandlerContext;Lio/netty/buffer/ByteBuf;Ljava/util/List;)V	decode	decode
-CLASS	i	net/minecraft/class_4374
+CLASS	i	net/minecraft/class_4375
 CLASS	ia	net/minecraft/class_1974
 FIELD	ia	Lorg/apache/logging/log4j/Logger;	a	field_8469
 FIELD	ia	Lorg/apache/logging/log4j/Marker;	b	field_8470
@@ -28053,7 +28053,7 @@ METHOD	ia	(Lio/netty/channel/ChannelHandlerContext;Liv;Lio/netty/buffer/ByteBuf;
 METHOD	ia	(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;Lio/netty/buffer/ByteBuf;)V	encode	encode
 CLASS	ib	net/minecraft/class_701
 METHOD	ib	(Lij;)V	a	method_7456
-CLASS	ic	net/minecraft/class_4375
+CLASS	ic	net/minecraft/class_4376
 CLASS	id	net/minecraft/class_1975
 METHOD	id	(Lio/netty/channel/ChannelHandlerContext;Lio/netty/buffer/ByteBuf;Ljava/util/List;)V	decode	decode
 CLASS	ie	net/minecraft/class_1976
@@ -28609,15 +28609,15 @@ FIELD	jp	Lcom/mojang/brigadier/suggestion/Suggestions;	b	field_21524
 METHOD	jp	(Liy;)V	a	method_7700
 METHOD	jp	()I	b	method_20208
 METHOD	jp	()Lcom/mojang/brigadier/suggestion/Suggestions;	c	method_20209
-CLASS	jq	net/minecraft/class_4376
+CLASS	jq	net/minecraft/class_4377
 FIELD	jq	Lcom/mojang/brigadier/tree/RootCommandNode;	a	field_21525
 METHOD	jq	(Lhy;B)Lcom/mojang/brigadier/builder/ArgumentBuilder;	a	method_20210
 METHOD	jq	(Lhy;Lcom/mojang/brigadier/tree/CommandNode;Ljava/util/Map;)V	a	method_20211
 METHOD	jq	(Liy;)V	a	method_20212
 METHOD	jq	()Lcom/mojang/brigadier/tree/RootCommandNode;	b	method_20213
 METHOD	jq	(Lhy;)Ljq$a;	c	method_20214
-CLASS	jq$1	net/minecraft/class_4376$1
-CLASS	jq$a	net/minecraft/class_4376$class_4377
+CLASS	jq$1	net/minecraft/class_4377$1
+CLASS	jq$a	net/minecraft/class_4377$class_4378
 FIELD	jq$a	Lcom/mojang/brigadier/builder/ArgumentBuilder;	a	field_21526
 FIELD	jq$a	B	b	field_21527
 FIELD	jq$a	I	c	field_21528
@@ -28733,7 +28733,7 @@ METHOD	k	()Ljava/util/stream/Stream;	f	method_20232
 METHOD	k	()Lit/unimi/dsi/fastutil/Hash$Strategy;	g	method_20233
 METHOD	k	()Lorg/apache/logging/log4j/Logger;	h	method_20234
 CLASS	k$1	net/minecraft/class_1723$1
-CLASS	k$a	net/minecraft/class_1723$class_4378
+CLASS	k$a	net/minecraft/class_1723$class_4379
 FIELD	k$a	Lk$a;	a	field_21544
 FIELD	k$a	[Lk$a;	b	field_21545
 METHOD	k$a	(Ljava/lang/Object;Ljava/lang/Object;)Z	equals	equals
@@ -28991,7 +28991,7 @@ METHOD	kr$b	()I	b	method_10672
 METHOD	kr$b	()Laxv;	c	method_10673
 METHOD	kr$b	()Lij;	d	method_10674
 METHOD	kr$b	()Ljava/lang/String;	toString	toString
-CLASS	ks	net/minecraft/class_4379
+CLASS	ks	net/minecraft/class_4380
 FIELD	ks	D	a	field_21548
 FIELD	ks	D	b	field_21549
 FIELD	ks	D	c	field_21550
@@ -29330,7 +29330,7 @@ METHOD	lt	()D	e	method_7791
 METHOD	lt	()D	f	method_7792
 METHOD	lt	()F	g	method_7793
 METHOD	lt	()F	h	method_7794
-CLASS	lu	net/minecraft/class_4380
+CLASS	lu	net/minecraft/class_4381
 FIELD	lu	Lpc;	a	field_21570
 FIELD	lu	Lwk;	b	field_21571
 METHOD	lu	(Liy;)V	a	method_20264
@@ -29342,7 +29342,7 @@ FIELD	lv	Lij;	b	field_11693
 METHOD	lv	(Liy;)V	a	method_10696
 METHOD	lv	()Lij;	b	method_10695
 METHOD	lv	()Lij;	c	method_10697
-CLASS	lw	net/minecraft/class_4381
+CLASS	lw	net/minecraft/class_4382
 FIELD	lw	I	a	field_21572
 FIELD	lw	Lgy;	b	field_21573
 METHOD	lw	(Liy;)V	a	method_20267
@@ -29431,11 +29431,11 @@ METHOD	mb	()I	f	method_10718
 METHOD	mb	()Z	g	method_10719
 METHOD	mb	()Z	h	method_12677
 METHOD	mb	()Z	i	method_20271
-CLASS	mc	net/minecraft/class_4382
+CLASS	mc	net/minecraft/class_4383
 FIELD	mc	Ljava/util/List;	a	field_21574
 METHOD	mc	(Liy;)V	a	method_20272
 METHOD	mc	()Ljava/util/List;	b	method_20273
-CLASS	md	net/minecraft/class_4383
+CLASS	md	net/minecraft/class_4384
 FIELD	md	Lxb;	a	field_21575
 METHOD	md	(Liy;)V	a	method_20274
 METHOD	md	()Lxb;	b	method_20275
@@ -29484,7 +29484,7 @@ CLASS	mf	net/minecraft/class_2917
 FIELD	mf	I	a	field_13795
 METHOD	mf	(Lme;)V	a	method_12683
 METHOD	mf	()I	b	method_12682
-CLASS	mg	net/minecraft/class_4384
+CLASS	mg	net/minecraft/class_4385
 FIELD	mg	I	a	field_21576
 FIELD	mg	Lel;	b	field_21577
 METHOD	mg	(Lme;)V	a	method_20286
@@ -29558,7 +29558,7 @@ FIELD	mp	Lpc;	a	field_21579
 FIELD	mp	Lpc;	b	field_21580
 FIELD	mp	Lhy;	c	field_11702
 METHOD	mp	(Lme;)V	a	method_7979
-CLASS	mq	net/minecraft/class_4385
+CLASS	mq	net/minecraft/class_4386
 FIELD	mq	Late;	a	field_21581
 FIELD	mq	Z	b	field_21582
 FIELD	mq	Ladk;	c	field_21583
@@ -29566,7 +29566,7 @@ METHOD	mq	(Lme;)V	a	method_20290
 METHOD	mq	()Late;	b	method_20291
 METHOD	mq	()Z	c	method_20292
 METHOD	mq	()Ladk;	d	method_20293
-CLASS	mr	net/minecraft/class_4386
+CLASS	mr	net/minecraft/class_4387
 FIELD	mr	I	a	field_21584
 FIELD	mr	I	b	field_21585
 METHOD	mr	(Lme;)V	a	method_20294
@@ -29630,7 +29630,7 @@ FIELD	mw	Z	b	field_13806
 METHOD	mw	(Lme;)V	a	method_12699
 METHOD	mw	()Z	b	method_12698
 METHOD	mw	()Z	c	method_12700
-CLASS	mx	net/minecraft/class_4387
+CLASS	mx	net/minecraft/class_4388
 FIELD	mx	I	a	field_21586
 METHOD	mx	(Lme;)V	a	method_20297
 METHOD	mx	()I	b	method_20298
@@ -29756,7 +29756,7 @@ FIELD	nd$a	Lnd$a;	b	field_16319
 FIELD	nd$a	[Lnd$a;	c	field_16320
 METHOD	nd$a	(Ljava/lang/String;)Lnd$a;	valueOf	valueOf
 METHOD	nd$a	()[Lnd$a;	values	values
-CLASS	ne	net/minecraft/class_4388
+CLASS	ne	net/minecraft/class_4389
 FIELD	ne	Ljava/lang/String;	a	field_21591
 METHOD	ne	(Lme;)V	a	method_20302
 METHOD	ne	()Ljava/lang/String;	b	method_20303
@@ -30426,11 +30426,11 @@ FIELD	ng$a	Lng$a;	b	field_16324
 FIELD	ng$a	[Lng$a;	c	field_16325
 METHOD	ng$a	(Ljava/lang/String;)Lng$a;	valueOf	valueOf
 METHOD	ng$a	()[Lng$a;	values	values
-CLASS	nh	net/minecraft/class_4389
+CLASS	nh	net/minecraft/class_4390
 FIELD	nh	I	a	field_21615
 METHOD	nh	(Lme;)V	a	method_20352
 METHOD	nh	()I	b	method_20353
-CLASS	ni	net/minecraft/class_4390
+CLASS	ni	net/minecraft/class_4391
 FIELD	ni	I	a	field_21616
 FIELD	ni	I	b	field_21617
 METHOD	ni	(Lme;)V	a	method_20354
@@ -30440,7 +30440,7 @@ CLASS	nj	net/minecraft/class_2068
 FIELD	nj	I	a	field_8823
 METHOD	nj	(Lme;)V	a	method_8027
 METHOD	nj	()I	b	method_8028
-CLASS	nk	net/minecraft/class_4391
+CLASS	nk	net/minecraft/class_4392
 FIELD	nk	Lel;	a	field_21618
 FIELD	nk	Ljava/lang/String;	b	field_21619
 FIELD	nk	Z	c	field_21620
@@ -30454,7 +30454,7 @@ METHOD	nk	()Z	d	method_20360
 METHOD	nk	()Z	e	method_20361
 METHOD	nk	()Z	f	method_20362
 METHOD	nk	()Lbjm$a;	g	method_20363
-CLASS	nl	net/minecraft/class_4392
+CLASS	nl	net/minecraft/class_4393
 FIELD	nl	I	a	field_21624
 FIELD	nl	Ljava/lang/String;	b	field_21625
 FIELD	nl	Z	c	field_21626
@@ -30468,7 +30468,7 @@ FIELD	nm	Late;	b	field_8825
 METHOD	nm	(Lme;)V	a	method_8029
 METHOD	nm	()I	b	method_8030
 METHOD	nm	()Late;	c	method_8031
-CLASS	nn	net/minecraft/class_4393
+CLASS	nn	net/minecraft/class_4394
 FIELD	nn	Lel;	a	field_21627
 FIELD	nn	Lbkf$a;	b	field_21628
 FIELD	nn	Lbmr;	c	field_21629
@@ -30546,7 +30546,7 @@ METHOD	nx	(Lnz;)V	a	method_8049
 METHOD	nx	(Loa;)V	a	method_8050
 METHOD	nx	(Lob;)V	a	method_10733
 METHOD	nx	(Loc;)V	a	method_8051
-CLASS	ny	net/minecraft/class_4394
+CLASS	ny	net/minecraft/class_4395
 FIELD	ny	I	a	field_21641
 FIELD	ny	Lpc;	b	field_21642
 FIELD	ny	Lhy;	c	field_21643
@@ -30565,7 +30565,7 @@ FIELD	o	Lbr$a;	e	field_16307
 METHOD	o	(Ltf;)V	a	method_14859
 METHOD	o	()Lcom/google/gson/JsonElement;	b	method_20386
 METHOD	o	()Ljava/lang/String;	toString	toString
-CLASS	o$a	net/minecraft/class_3337$class_4395
+CLASS	o$a	net/minecraft/class_3337$class_4396
 FIELD	o$a	I	a	field_21644
 FIELD	o$a	Ljava/util/List;	b	field_21645
 FIELD	o$a	Ljava/util/List;	c	field_21646
@@ -30598,7 +30598,7 @@ CLASS	od	net/minecraft/class_2076
 METHOD	od	(Loe;)V	a	method_20392
 METHOD	od	(Lof;)V	a	method_8056
 METHOD	od	(Log;)V	a	method_8057
-CLASS	oe	net/minecraft/class_4396
+CLASS	oe	net/minecraft/class_4397
 FIELD	oe	I	a	field_21648
 FIELD	oe	Lhy;	b	field_21649
 METHOD	oe	(Lod;)V	a	method_20393
@@ -30807,10 +30807,10 @@ METHOD	ou$a	(Z)V	a	method_2709
 METHOD	ou$a	()Ljava/lang/Object;	b	method_2710
 METHOD	ou$a	()Z	c	method_2712
 METHOD	ou$a	()Lou$a;	d	method_14902
-CLASS	oy	net/minecraft/class_4397
+CLASS	oy	net/minecraft/class_4398
 METHOD	oy	(IIILavk;Ljava/util/Iterator;I)V	a	method_20429
 METHOD	oy	(Ljava/util/Iterator;IIII)V	a	method_20430
-CLASS	oz	net/minecraft/class_4398
+CLASS	oz	net/minecraft/class_4399
 FIELD	oz	Lorg/apache/logging/log4j/Logger;	a	field_21652
 FIELD	oz	Laoi;	b	field_21653
 FIELD	oz	Laof;	c	field_21654
@@ -30823,7 +30823,7 @@ METHOD	oz	(Ltf;Lavk;Z)V	a	method_20435
 METHOD	oz	(ZIZ)I	a	method_20436
 METHOD	oz	()Z	b	method_20437
 METHOD	oz	()I	c	method_20438
-CLASS	p	net/minecraft/class_815
+CLASS	p	net/minecraft/class_3344
 FIELD	p	Laj;	A	field_16354
 FIELD	p	Lbm;	B	field_16326
 FIELD	p	Lbd;	C	field_16327
@@ -30859,7 +30859,7 @@ FIELD	p	Lae;	z	field_16353
 METHOD	p	()Ljava/lang/Iterable;	a	method_14875
 METHOD	p	(Lpc;)Ls;	a	method_14876
 METHOD	p	(Ls;)Ls;	a	method_14877
-CLASS	pa	net/minecraft/class_4399
+CLASS	pa	net/minecraft/class_4400
 FIELD	pa	Z	e	field_21659
 METHOD	pa	(ILit/unimi/dsi/fastutil/ints/IntList;)V	a	method_20439
 CLASS	pc	net/minecraft/class_1653
@@ -30880,7 +30880,7 @@ METHOD	pc	(Ljava/lang/Object;)I	compareTo	compareTo
 METHOD	pc	(Ljava/lang/Object;)Z	equals	equals
 METHOD	pc	()I	hashCode	hashCode
 METHOD	pc	()Ljava/lang/String;	toString	toString
-CLASS	pc$a	net/minecraft/class_1653$class_3346
+CLASS	pc$a	net/minecraft/class_1653$class_3347
 METHOD	pc$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lpc;	a	method_14915
 METHOD	pc$a	(Lpc;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;	a	method_14916
 METHOD	pc$a	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
@@ -30932,7 +30932,7 @@ CLASS	pf$9	net/minecraft/class_1541$9
 CLASS	pf$a	net/minecraft/class_1541$class_2924
 FIELD	pf$a	Leo;	a	field_13843
 FIELD	pf$a	Lapj$b;	b	field_13844
-CLASS	pf$b	net/minecraft/class_1541$class_4400
+CLASS	pf$b	net/minecraft/class_1541$class_4401
 FIELD	pf$b	Leq;	j	field_21662
 CLASS	pf$c	net/minecraft/class_1541$class_3115
 FIELD	pf$c	Z	a	field_15356
@@ -30970,7 +30970,7 @@ FIELD	pl	Ljava/lang/String;	b	field_11750
 METHOD	pl	(Ljava/lang/String;)V	a	method_10742
 METHOD	pl	(Ljava/lang/Object;)V	println	println
 METHOD	pl	(Ljava/lang/String;)V	println	println
-CLASS	pm	net/minecraft/class_3347
+CLASS	pm	net/minecraft/class_3348
 FIELD	pm	Lorg/apache/logging/log4j/Logger;	a	field_16366
 FIELD	pm	Lcom/google/gson/Gson;	b	field_16367
 FIELD	pm	Lcom/google/gson/reflect/TypeToken;	c	field_16368
@@ -31002,11 +31002,11 @@ METHOD	pm	()V	f	method_14932
 METHOD	pm	(Ll;)Z	f	method_14933
 METHOD	pm	()V	g	method_14934
 METHOD	pm	(Ll;)Z	g	method_14935
-CLASS	pm$1	net/minecraft/class_3347$1
+CLASS	pm$1	net/minecraft/class_3348$1
 CLASS	pn	net/minecraft/class_2596
 FIELD	pn	Lpn;	a	field_11751
 METHOD	pn	()Ljava/lang/Throwable;	fillInStackTrace	fillInStackTrace
-CLASS	po	net/minecraft/class_3348
+CLASS	po	net/minecraft/class_3349
 FIELD	po	I	a	field_21663
 FIELD	po	I	b	field_21664
 FIELD	po	Lorg/apache/logging/log4j/Logger;	c	field_16378
@@ -31018,7 +31018,7 @@ METHOD	po	(Ljava/lang/String;)Z	a	method_20450
 METHOD	po	(Lpc;)Ll;	a	method_14938
 METHOD	po	()Ljava/util/Collection;	b	method_20451
 METHOD	po	(Lvf;)Ljava/util/Map;	b	method_20452
-CLASS	pp	net/minecraft/class_3349
+CLASS	pp	net/minecraft/class_3350
 FIELD	pp	I	a	field_21665
 FIELD	pp	I	b	field_21666
 FIELD	pp	Lorg/apache/logging/log4j/Logger;	c	field_16383
@@ -31046,7 +31046,7 @@ METHOD	pp	()Ljava/util/Map;	c	method_14949
 METHOD	pp	()Lcom/mojang/brigadier/CommandDispatcher;	d	method_20461
 METHOD	pp	()Lbu;	f	method_20462
 METHOD	pp	()Lxa;	g	method_20463
-CLASS	pp$a	net/minecraft/class_3349$class_3350
+CLASS	pp$a	net/minecraft/class_3350$class_3351
 FIELD	pp$a	Lpp;	a	field_16393
 FIELD	pp$a	Lbu;	b	field_16394
 FIELD	pp$a	Lbr$c;	c	field_16395
@@ -31084,7 +31084,7 @@ METHOD	pr	(Lcez;)V	e	method_5300
 METHOD	pr	(Lcez;)Ljava/util/List;	f	method_5301
 METHOD	pr	(Lcez;)V	g	method_5302
 METHOD	pr	(Lcez;)I	h	method_5303
-CLASS	pr$a	net/minecraft/class_1545$class_4401
+CLASS	pr$a	net/minecraft/class_1545$class_4402
 FIELD	pr$a	Lpr$a;	a	field_21672
 FIELD	pr$a	Lpr$a;	b	field_21673
 FIELD	pr$a	[Lpr$a;	c	field_21674
@@ -31106,7 +31106,7 @@ METHOD	ps	(Ljava/lang/String;)V	b	method_12761
 METHOD	ps	()Ljava/io/File;	c	method_2052
 CLASS	pt	net/minecraft/class_746
 METHOD	pt	()V	Y_	method_2053
-CLASS	pu	net/minecraft/class_4402
+CLASS	pu	net/minecraft/class_4403
 FIELD	pu	Lpc;	h	field_21675
 FIELD	pu	Ljava/util/Set;	i	field_21676
 FIELD	pu	I	j	field_21677
@@ -31124,7 +31124,7 @@ METHOD	pu	()I	d	method_20473
 METHOD	pu	(Ltf;)V	d	method_20474
 METHOD	pu	()Lij;	e	method_20475
 METHOD	pu	()Lgy;	f	method_20476
-CLASS	pv	net/minecraft/class_4403
+CLASS	pv	net/minecraft/class_4404
 FIELD	pv	Lnet/minecraft/server/MinecraftServer;	a	field_21679
 FIELD	pv	Ljava/util/Map;	b	field_21680
 METHOD	pv	()Ljava/util/Collection;	a	method_20477
@@ -31136,7 +31136,7 @@ METHOD	pv	(Ltf;)V	a	method_20482
 METHOD	pv	()Ljava/util/Collection;	b	method_20483
 METHOD	pv	(Ltf;)V	b	method_20484
 METHOD	pv	()Lgy;	c	method_20485
-CLASS	px	net/minecraft/class_4404
+CLASS	px	net/minecraft/class_4405
 FIELD	px	Lcom/mojang/brigadier/suggestion/SuggestionProvider;	a	field_21681
 METHOD	px	(Lbu;)Z	a	method_20486
 METHOD	px	(Lbu;Ljava/util/Collection;Lpx$a;Ljava/util/Collection;)I	a	method_20487
@@ -31159,8 +31159,8 @@ METHOD	px	(Lcom/mojang/brigadier/context/CommandContext;)I	i	method_20503
 METHOD	px	(Lcom/mojang/brigadier/context/CommandContext;)I	j	method_20504
 METHOD	px	(Lcom/mojang/brigadier/context/CommandContext;)I	k	method_20505
 METHOD	px	(Lcom/mojang/brigadier/context/CommandContext;)I	l	method_20506
-CLASS	px$1	net/minecraft/class_4404$1
-CLASS	px$a	net/minecraft/class_4404$class_3293
+CLASS	px$1	net/minecraft/class_4405$1
+CLASS	px$a	net/minecraft/class_4405$class_3293
 FIELD	px$a	Lpx$a;	a	field_16111
 FIELD	px$a	Lpx$a;	b	field_16112
 FIELD	px$a	Ljava/lang/String;	c	field_16114
@@ -31171,9 +31171,9 @@ METHOD	px$a	(Ltf;Ll;)Z	a	method_14657
 METHOD	px$a	(Ltf;Ll;Ljava/lang/String;)Z	a	method_14658
 METHOD	px$a	(Ljava/lang/String;)Lpx$a;	valueOf	valueOf
 METHOD	px$a	()[Lpx$a;	values	values
-CLASS	px$a$1	net/minecraft/class_4404$class_3293$1
-CLASS	px$a$2	net/minecraft/class_4404$class_3293$2
-CLASS	px$b	net/minecraft/class_4404$class_4405
+CLASS	px$a$1	net/minecraft/class_4405$class_3293$1
+CLASS	px$a$2	net/minecraft/class_4405$class_3293$2
+CLASS	px$b	net/minecraft/class_4405$class_4406
 FIELD	px$b	Lpx$b;	a	field_21682
 FIELD	px$b	Lpx$b;	b	field_21683
 FIELD	px$b	Lpx$b;	c	field_21684
@@ -31196,14 +31196,14 @@ METHOD	py	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20512
 METHOD	py	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20513
 METHOD	py	(Lbu;Ljava/lang/String;Lij;)I	b	method_20514
 METHOD	py	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_20515
-CLASS	pz	net/minecraft/class_4406
+CLASS	pz	net/minecraft/class_4407
 METHOD	pz	(Lbu;)Z	a	method_20516
 METHOD	pz	(Lbu;Ljava/util/Collection;)I	a	method_20517
 METHOD	pz	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20518
 METHOD	pz	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20519
 METHOD	pz	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_20520
 METHOD	pz	(Lcom/mojang/brigadier/context/CommandContext;)I	c	method_20521
-CLASS	q	net/minecraft/class_3344
+CLASS	q	net/minecraft/class_3345
 FIELD	q	Lt;	a	field_16355
 METHOD	q	()Lt;	a	method_14879
 METHOD	q	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lq;	a	method_14880
@@ -31213,14 +31213,14 @@ METHOD	q	()Lcom/google/gson/JsonElement;	b	method_20522
 METHOD	q	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Ljava/util/Map;	b	method_14883
 METHOD	q	(Lhy;)Lq;	b	method_14884
 METHOD	q	(Lhy;)Ljava/util/Map;	c	method_14885
-CLASS	qa	net/minecraft/class_4407
+CLASS	qa	net/minecraft/class_4408
 FIELD	qa	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21692
 METHOD	qa	(Lbu;)Z	a	method_20523
 METHOD	qa	(Lbu;Ljava/util/Collection;Lij;)I	a	method_20524
 METHOD	qa	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20525
 METHOD	qa	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20526
 METHOD	qa	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_20527
-CLASS	qb	net/minecraft/class_4408
+CLASS	qb	net/minecraft/class_4409
 FIELD	qb	Lcom/mojang/brigadier/suggestion/SuggestionProvider;	a	field_21693
 FIELD	qb	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21694
 FIELD	qb	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_21695
@@ -31277,7 +31277,7 @@ METHOD	qb	(Lcom/mojang/brigadier/context/CommandContext;)I	w	method_20569
 METHOD	qb	(Lcom/mojang/brigadier/context/CommandContext;)I	x	method_20570
 METHOD	qb	(Lcom/mojang/brigadier/context/CommandContext;)I	y	method_20571
 METHOD	qb	(Lcom/mojang/brigadier/context/CommandContext;)I	z	method_20572
-CLASS	qc	net/minecraft/class_4409
+CLASS	qc	net/minecraft/class_4410
 FIELD	qc	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_21704
 FIELD	qc	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21705
 METHOD	qc	(Late;)Z	a	method_20573
@@ -31291,7 +31291,7 @@ METHOD	qc	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_20580
 METHOD	qc	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	b	method_20581
 METHOD	qc	(Lcom/mojang/brigadier/context/CommandContext;)I	c	method_20582
 METHOD	qc	(Lcom/mojang/brigadier/context/CommandContext;)I	d	method_20583
-CLASS	qd	net/minecraft/class_4410
+CLASS	qd	net/minecraft/class_4411
 FIELD	qd	Ljava/util/function/Predicate;	a	field_21706
 FIELD	qd	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21707
 FIELD	qd	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	c	field_21708
@@ -31319,11 +31319,11 @@ METHOD	qd	(Lcom/mojang/brigadier/context/CommandContext;)I	j	method_20603
 METHOD	qd	(Lcom/mojang/brigadier/context/CommandContext;)I	k	method_20604
 METHOD	qd	(Lcom/mojang/brigadier/context/CommandContext;)I	l	method_20605
 METHOD	qd	(Lcom/mojang/brigadier/context/CommandContext;)I	m	method_20606
-CLASS	qd$a	net/minecraft/class_4410$class_2635
+CLASS	qd$a	net/minecraft/class_4411$class_2635
 FIELD	qd$a	Lel;	a	field_12011
 FIELD	qd$a	Lblc;	b	field_12012
 FIELD	qd$a	Lgy;	c	field_12013
-CLASS	qd$b	net/minecraft/class_4410$class_4411
+CLASS	qd$b	net/minecraft/class_4411$class_4412
 FIELD	qd$b	Lqd$b;	a	field_21710
 FIELD	qd$b	Lqd$b;	b	field_21711
 FIELD	qd$b	Lqd$b;	c	field_21712
@@ -31332,7 +31332,7 @@ FIELD	qd$b	[Lqd$b;	e	field_21714
 METHOD	qd$b	()Z	a	method_20607
 METHOD	qd$b	(Ljava/lang/String;)Lqd$b;	valueOf	valueOf
 METHOD	qd$b	()[Lqd$b;	values	values
-CLASS	qe	net/minecraft/class_4412
+CLASS	qe	net/minecraft/class_4413
 FIELD	qe	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_21715
 FIELD	qe	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21716
 FIELD	qe	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_21717
@@ -31369,7 +31369,7 @@ METHOD	qe	(Lcom/mojang/brigadier/context/CommandContext;)I	f	method_20635
 METHOD	qe	(Lcom/mojang/brigadier/context/CommandContext;)I	g	method_20636
 METHOD	qe	(Lcom/mojang/brigadier/context/CommandContext;)I	h	method_20637
 METHOD	qe	(Lcom/mojang/brigadier/context/CommandContext;)I	i	method_20638
-CLASS	qe$a	net/minecraft/class_4412$class_4413
+CLASS	qe$a	net/minecraft/class_4413$class_4414
 METHOD	qe$a	(Ljava/util/List;Lva;)V	apply	apply
 CLASS	qf	net/minecraft/class_751
 FIELD	qf	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21720
@@ -31378,7 +31378,7 @@ METHOD	qf	(Lbu;Ljava/util/Collection;)I	a	method_20640
 METHOD	qf	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20641
 METHOD	qf	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20642
 METHOD	qf	(Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;	a	method_20643
-CLASS	qg	net/minecraft/class_4414
+CLASS	qg	net/minecraft/class_4415
 FIELD	qg	Lorg/apache/logging/log4j/Logger;	a	field_21721
 FIELD	qg	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21722
 FIELD	qg	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_21723
@@ -31391,7 +31391,7 @@ METHOD	qg	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20649
 METHOD	qg	(Lbu;)I	b	method_20650
 METHOD	qg	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_20651
 METHOD	qg	(Lbu;)Z	c	method_20652
-CLASS	qh	net/minecraft/class_4415
+CLASS	qh	net/minecraft/class_4416
 METHOD	qh	(Laxv;Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20653
 METHOD	qh	(Lbu;)Z	a	method_20654
 METHOD	qh	(Lbu;Laxv;)I	a	method_20655
@@ -31404,7 +31404,7 @@ METHOD	qi	(Lbu;Ladi;)I	a	method_20659
 METHOD	qi	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20660
 METHOD	qi	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20661
 METHOD	qi	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	a	method_20662
-CLASS	qj	net/minecraft/class_4416
+CLASS	qj	net/minecraft/class_4417
 FIELD	qj	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21725
 FIELD	qj	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21726
 FIELD	qj	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_21727
@@ -31419,10 +31419,10 @@ METHOD	qj	(Lcom/mojang/brigadier/context/CommandContext;)I	c	method_20670
 METHOD	qj	(Lcom/mojang/brigadier/context/CommandContext;)I	d	method_20671
 METHOD	qj	(Lcom/mojang/brigadier/context/CommandContext;)I	e	method_20672
 METHOD	qj	(Lcom/mojang/brigadier/context/CommandContext;)I	f	method_20673
-CLASS	qk	net/minecraft/class_4417
+CLASS	qk	net/minecraft/class_4418
 METHOD	qk	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20674
 METHOD	qk	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20675
-CLASS	ql	net/minecraft/class_4418
+CLASS	ql	net/minecraft/class_4419
 FIELD	ql	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	a	field_21728
 FIELD	ql	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21729
 FIELD	ql	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_21730
@@ -31437,7 +31437,7 @@ METHOD	ql	(Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	a
 METHOD	ql	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_20682
 METHOD	ql	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	b	method_20683
 METHOD	ql	(Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	c	method_20684
-CLASS	qm	net/minecraft/class_4419
+CLASS	qm	net/minecraft/class_4420
 FIELD	qm	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	a	field_21733
 FIELD	qm	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21734
 FIELD	qm	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_21735
@@ -31512,9 +31512,9 @@ METHOD	qm	(Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/Collection;	
 METHOD	qm	(Lcom/mojang/brigadier/context/CommandContext;)Lbu;	r	method_20752
 METHOD	qm	(Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/Collection;	s	method_20753
 METHOD	qm	(Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/Collection;	t	method_20754
-CLASS	qm$a	net/minecraft/class_4419$class_4420
+CLASS	qm$a	net/minecraft/class_4420$class_4421
 METHOD	qm$a	(Lcom/mojang/brigadier/context/CommandContext;)Z	test	test
-CLASS	qn	net/minecraft/class_4421
+CLASS	qn	net/minecraft/class_4422
 FIELD	qn	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21737
 METHOD	qn	(Lbu;)Z	a	method_20755
 METHOD	qn	(Lbu;Ljava/util/Collection;ILqn$a;)I	a	method_20756
@@ -31530,7 +31530,7 @@ METHOD	qn	(Lcom/mojang/brigadier/context/CommandContext;)I	e	method_20765
 METHOD	qn	(Lcom/mojang/brigadier/context/CommandContext;)I	f	method_20766
 METHOD	qn	(Lcom/mojang/brigadier/context/CommandContext;)I	g	method_20767
 METHOD	qn	(Lcom/mojang/brigadier/context/CommandContext;)I	h	method_20768
-CLASS	qn$a	net/minecraft/class_4421$class_4422
+CLASS	qn$a	net/minecraft/class_4422$class_4423
 FIELD	qn$a	Lqn$a;	a	field_21738
 FIELD	qn$a	Lqn$a;	b	field_21739
 FIELD	qn$a	Ljava/util/function/BiConsumer;	c	field_21740
@@ -31562,7 +31562,7 @@ METHOD	qo	(Lcom/mojang/brigadier/context/CommandContext;)I	d	method_20783
 METHOD	qo	(Lcom/mojang/brigadier/context/CommandContext;)I	e	method_20784
 METHOD	qo	(Lcom/mojang/brigadier/context/CommandContext;)I	f	method_20785
 METHOD	qo	(Lcom/mojang/brigadier/context/CommandContext;)I	g	method_20786
-CLASS	qo$a	net/minecraft/class_2170$class_4423
+CLASS	qo$a	net/minecraft/class_2170$class_4424
 FIELD	qo$a	Lqo$a;	a	field_21748
 FIELD	qo$a	Lqo$a;	b	field_21749
 FIELD	qo$a	Lqo$a;	c	field_21750
@@ -31575,7 +31575,7 @@ METHOD	qo$a	(Lbwf;Lel;Lct;Ltd;)Lct;	c	method_20789
 METHOD	qo$a	(Lbwf;Lel;Lct;Ltd;)Lct;	d	method_20790
 METHOD	qo$a	(Ljava/lang/String;)Lqo$a;	valueOf	valueOf
 METHOD	qo$a	()[Lqo$a;	values	values
-CLASS	qp	net/minecraft/class_4424
+CLASS	qp	net/minecraft/class_4425
 FIELD	qp	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	a	field_21754
 FIELD	qp	Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;	b	field_21755
 FIELD	qp	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_21756
@@ -31639,7 +31639,7 @@ METHOD	qw	(Lbu;)Z	a	method_20836
 METHOD	qw	(Lbu;Ljava/util/Collection;)I	a	method_20837
 METHOD	qw	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20838
 METHOD	qw	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20839
-CLASS	qx	net/minecraft/class_4425
+CLASS	qx	net/minecraft/class_4426
 METHOD	qx	(Lbu;)I	a	method_20840
 METHOD	qx	(Lbu;Ljava/util/function/Function;)I	a	method_20841
 METHOD	qx	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20842
@@ -31671,7 +31671,7 @@ CLASS	qz	net/minecraft/class_757
 METHOD	qz	(Lbu;Ljava/util/Collection;Lij;)I	a	method_20865
 METHOD	qz	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20866
 METHOD	qz	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20867
-CLASS	r	net/minecraft/class_3351
+CLASS	r	net/minecraft/class_3352
 FIELD	r	Ljava/text/SimpleDateFormat;	a	field_16396
 FIELD	r	Ljava/util/Date;	b	field_16398
 METHOD	r	()Z	a	method_14953
@@ -31786,7 +31786,7 @@ FIELD	rl	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21
 METHOD	rl	(Lbu;)Z	a	method_20940
 METHOD	rl	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20941
 METHOD	rl	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20942
-CLASS	rm	net/minecraft/class_4426
+CLASS	rm	net/minecraft/class_4427
 METHOD	rm	(Lbu;)Z	a	method_20943
 METHOD	rm	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_20944
 METHOD	rm	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20945
@@ -31853,9 +31853,9 @@ METHOD	rp	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_20995
 METHOD	rp	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_20996
 METHOD	rp	(Lcom/mojang/brigadier/context/CommandContext;)I	c	method_20997
 METHOD	rp	(Lcom/mojang/brigadier/context/CommandContext;)I	d	method_20998
-CLASS	rp$a	net/minecraft/class_1860$class_4427
+CLASS	rp$a	net/minecraft/class_1860$class_4428
 METHOD	rp$a	(Lbwf;Lel;Lct;Ltd;)Lct;	filter	filter
-CLASS	rp$b	net/minecraft/class_1860$class_4428
+CLASS	rp$b	net/minecraft/class_1860$class_4429
 FIELD	rp$b	Lrp$b;	a	field_21784
 FIELD	rp$b	Lrp$b;	b	field_21785
 FIELD	rp$b	Lrp$b;	c	field_21786
@@ -31863,7 +31863,7 @@ FIELD	rp$b	Lrp$b;	d	field_21787
 FIELD	rp$b	[Lrp$b;	e	field_21788
 METHOD	rp$b	(Ljava/lang/String;)Lrp$b;	valueOf	valueOf
 METHOD	rp$b	()[Lrp$b;	values	values
-CLASS	rq	net/minecraft/class_4429
+CLASS	rq	net/minecraft/class_4430
 METHOD	rq	(Lbu;)Z	a	method_20999
 METHOD	rq	(Lbu;I)I	a	method_21000
 METHOD	rq	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_21001
@@ -31875,13 +31875,13 @@ METHOD	rr	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_21005
 METHOD	rr	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_21006
 METHOD	rr	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_21007
 METHOD	rr	(Lcom/mojang/brigadier/context/CommandContext;)I	c	method_21008
-CLASS	rs	net/minecraft/class_4430
+CLASS	rs	net/minecraft/class_4431
 METHOD	rs	(Lbu;)Z	a	method_21009
 METHOD	rs	(Lbu;Lel;)I	a	method_21010
 METHOD	rs	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_21011
 METHOD	rs	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_21012
 METHOD	rs	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_21013
-CLASS	rt	net/minecraft/class_4431
+CLASS	rt	net/minecraft/class_4432
 FIELD	rt	Lcom/mojang/brigadier/exceptions/Dynamic4CommandExceptionType;	a	field_21789
 FIELD	rt	Lcom/mojang/brigadier/exceptions/Dynamic4CommandExceptionType;	b	field_21790
 METHOD	rt	(Lbu;)Z	a	method_21014
@@ -31894,7 +31894,7 @@ METHOD	rt	(Ljava/util/Collection;)I	a	method_21020
 METHOD	rt	(Ljava/util/Collection;Ltd;[Lrt$a;Z)D	a	method_21021
 METHOD	rt	(Ljava/util/Random;IDDDD)[Lrt$a;	a	method_21022
 METHOD	rt	(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;	b	method_21023
-CLASS	rt$a	net/minecraft/class_4431$class_1598
+CLASS	rt$a	net/minecraft/class_4432$class_1598
 FIELD	rt$a	D	a	field_6263
 FIELD	rt$a	D	b	field_6264
 METHOD	rt$a	()V	a	method_5557
@@ -31929,7 +31929,7 @@ METHOD	rw	(Lcom/mojang/brigadier/CommandDispatcher;)V	a	method_21042
 METHOD	rw	(Lcom/mojang/brigadier/context/CommandContext;)I	a	method_21043
 METHOD	rw	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_21044
 METHOD	rw	(Lcom/mojang/brigadier/context/CommandContext;)I	c	method_21045
-CLASS	rx	net/minecraft/class_4432
+CLASS	rx	net/minecraft/class_4433
 FIELD	rx	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21792
 FIELD	rx	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21793
 METHOD	rx	(Lbu;)Z	a	method_21046
@@ -31942,7 +31942,7 @@ METHOD	rx	(Ljava/util/Collection;)Ljava/util/Collection;	a	method_21052
 METHOD	rx	(Lbu;Ljava/util/Collection;Ljava/lang/String;)I	b	method_21053
 METHOD	rx	(Lcom/mojang/brigadier/context/CommandContext;)I	b	method_21054
 METHOD	rx	(Lcom/mojang/brigadier/context/CommandContext;)I	c	method_21055
-CLASS	ry	net/minecraft/class_4433
+CLASS	ry	net/minecraft/class_4434
 FIELD	ry	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	a	field_21794
 FIELD	ry	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	b	field_21795
 FIELD	ry	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	field_21796
@@ -32017,18 +32017,18 @@ METHOD	rz	(Lcom/mojang/brigadier/context/CommandContext;)I	e	method_21113
 METHOD	rz	(Lcom/mojang/brigadier/context/CommandContext;)I	f	method_21114
 METHOD	rz	(Lcom/mojang/brigadier/context/CommandContext;)I	g	method_21115
 METHOD	rz	(Lcom/mojang/brigadier/context/CommandContext;)I	h	method_21116
-CLASS	rz$a	net/minecraft/class_767$class_4434
+CLASS	rz$a	net/minecraft/class_767$class_4435
 FIELD	rz$a	Lcee;	a	field_21806
 FIELD	rz$a	Laer;	b	field_21807
 FIELD	rz$a	Lca$a;	c	field_21808
 METHOD	rz$a	(Lbu;Laer;)V	a	method_21117
-CLASS	s	net/minecraft/class_3352
+CLASS	s	net/minecraft/class_3353
 METHOD	s	()Lpc;	a	method_14970
 METHOD	s	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lt;	a	method_14971
 METHOD	s	(Lpm;)V	a	method_14972
 METHOD	s	(Lpm;Ls$a;)V	a	method_14973
 METHOD	s	(Lpm;Ls$a;)V	b	method_14974
-CLASS	s$a	net/minecraft/class_3352$class_3353
+CLASS	s$a	net/minecraft/class_3353$class_3354
 FIELD	s$a	Lt;	a	field_16406
 FIELD	s$a	Ll;	b	field_16407
 FIELD	s$a	Ljava/lang/String;	c	field_16408
@@ -32145,20 +32145,20 @@ METHOD	sg	(Lcom/mojang/brigadier/context/CommandContext;)I	g	method_21202
 METHOD	sg	(Lcom/mojang/brigadier/context/CommandContext;)I	h	method_21203
 METHOD	sg	(Lcom/mojang/brigadier/context/CommandContext;)I	i	method_21204
 METHOD	sg	(Lcom/mojang/brigadier/context/CommandContext;)I	j	method_21205
-CLASS	sh	net/minecraft/class_4435
+CLASS	sh	net/minecraft/class_4436
 FIELD	sh	Lsj$a;	a	field_21823
 FIELD	sh	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21824
 FIELD	sh	Lbji;	c	field_21825
 FIELD	sh	Lel;	d	field_21826
 METHOD	sh	()Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	c	method_21206
-CLASS	sh$1	net/minecraft/class_4435$1
-CLASS	si	net/minecraft/class_4436
+CLASS	sh$1	net/minecraft/class_4436$1
+CLASS	si	net/minecraft/class_4437
 METHOD	si	()Lgy;	a	method_21207
 METHOD	si	(Lci$c;DI)Lij;	a	method_21208
 METHOD	si	(Lgy;)V	a	method_21209
 METHOD	si	(Lho;)Lij;	a	method_21210
 METHOD	si	()Lij;	b	method_21211
-CLASS	sj	net/minecraft/class_4437
+CLASS	sj	net/minecraft/class_4438
 FIELD	sj	Ljava/util/List;	a	field_21827
 FIELD	sj	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21828
 FIELD	sj	Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;	c	field_21829
@@ -32180,14 +32180,14 @@ METHOD	sj	(Lsj$a;Lcom/mojang/brigadier/builder/ArgumentBuilder;)Lcom/mojang/brig
 METHOD	sj	(Lsj$a;Lcom/mojang/brigadier/context/CommandContext;)I	c	method_21226
 METHOD	sj	(Lsj$a;Lcom/mojang/brigadier/context/CommandContext;)I	d	method_21227
 METHOD	sj	(Lsj$a;Lcom/mojang/brigadier/context/CommandContext;)I	e	method_21228
-CLASS	sj$a	net/minecraft/class_4437$class_4438
+CLASS	sj$a	net/minecraft/class_4438$class_4439
 METHOD	sj$a	(Lcom/mojang/brigadier/builder/ArgumentBuilder;Ljava/util/function/Function;)Lcom/mojang/brigadier/builder/ArgumentBuilder;	a	method_21229
 METHOD	sj$a	(Lcom/mojang/brigadier/context/CommandContext;)Lsi;	a	method_21230
-CLASS	sk	net/minecraft/class_4439
+CLASS	sk	net/minecraft/class_4440
 FIELD	sk	Lsj$a;	a	field_21831
 FIELD	sk	Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;	b	field_21832
 FIELD	sk	Laer;	c	field_21833
-CLASS	sk$1	net/minecraft/class_4439$1
+CLASS	sk$1	net/minecraft/class_4440$1
 CLASS	sn	net/minecraft/class_769
 FIELD	sn	Lorg/apache/logging/log4j/Logger;	f	field_8869
 METHOD	sn	()V	A	method_8109
@@ -32316,10 +32316,10 @@ METHOD	sz	(I)Ljava/lang/String;	b	method_21240
 METHOD	sz	(Laer;)V	b	method_2101
 METHOD	sz	(Laer;Liv;)V	b	method_2102
 METHOD	sz	(Ltf;)V	b	method_2096
-CLASS	t	net/minecraft/class_3354
+CLASS	t	net/minecraft/class_3355
 METHOD	t	()Lpc;	a	method_14981
 METHOD	t	()Lcom/google/gson/JsonElement;	b	method_21241
-CLASS	ta	net/minecraft/class_4440
+CLASS	ta	net/minecraft/class_4441
 FIELD	ta	Lorg/apache/logging/log4j/Logger;	a	field_21836
 METHOD	ta	(J)Lbnj;	a	method_21242
 METHOD	ta	(JLbnj;)Lbnj;	a	method_21243
@@ -32588,7 +32588,7 @@ METHOD	th	()Liv;	e	method_2182
 METHOD	th	(Ltf;)Z	e	method_2187
 METHOD	th	(Ljava/lang/Object;)Z	equals	equals
 METHOD	th	()I	hashCode	hashCode
-CLASS	ti	net/minecraft/class_4441
+CLASS	ti	net/minecraft/class_4442
 FIELD	ti	Lorg/apache/logging/log4j/Logger;	a	field_21846
 FIELD	ti	[Lbnr;	b	field_21847
 FIELD	ti	I	c	field_21848
@@ -32610,7 +32610,7 @@ METHOD	ti	()I	b	method_21288
 METHOD	ti	(Lel;)V	i	method_21289
 METHOD	ti	(Lel;)Layo;	j	method_21290
 METHOD	ti	(Lel;)Layo;	k	method_21291
-CLASS	tj	net/minecraft/class_4442
+CLASS	tj	net/minecraft/class_4443
 FIELD	tj	Ljava/util/function/Function;	a	field_21861
 CLASS	tk	net/minecraft/class_2099
 FIELD	tk	Lorg/apache/logging/log4j/Logger;	a	field_13863
@@ -32682,20 +32682,20 @@ FIELD	tl$1	Ljava/util/Iterator;	a	field_21864
 FIELD	tl$1	Ltl;	b	field_21865
 METHOD	tl$1	()Lbnj;	a	method_21299
 METHOD	tl$1	()Ljava/lang/Object;	computeNext	computeNext
-CLASS	to	net/minecraft/class_4443
-CLASS	tp	net/minecraft/class_4444
-CLASS	tq	net/minecraft/class_4445
+CLASS	to	net/minecraft/class_4444
+CLASS	tp	net/minecraft/class_4445
+CLASS	tq	net/minecraft/class_4446
 FIELD	tq	Lorg/apache/logging/log4j/Logger;	a	field_21866
 METHOD	tq	(Lbnd;IILjava/util/Map;)[Lbnr;	a	method_21300
 METHOD	tq	(Lbnd;Laxy;Lbmy;Ljava/util/Map;II)Lbnr;	a	method_21301
 METHOD	tq	(Lbnd;Laxy;Lbmy;[Lbnr;II)Lbnr;	a	method_21302
-CLASS	tr	net/minecraft/class_4446
-CLASS	ts	net/minecraft/class_4447
-CLASS	tt	net/minecraft/class_4448
-CLASS	tu	net/minecraft/class_4449
-CLASS	tv	net/minecraft/class_4450
-CLASS	tw	net/minecraft/class_4451
-CLASS	tx	net/minecraft/class_4452
+CLASS	tr	net/minecraft/class_4447
+CLASS	ts	net/minecraft/class_4448
+CLASS	tt	net/minecraft/class_4449
+CLASS	tu	net/minecraft/class_4450
+CLASS	tv	net/minecraft/class_4451
+CLASS	tw	net/minecraft/class_4452
+CLASS	tx	net/minecraft/class_4453
 FIELD	tx	Lorg/apache/logging/log4j/Logger;	b	field_21867
 FIELD	tx	Laxy;	c	field_21868
 FIELD	tx	Lbmy;	d	field_21869
@@ -32711,7 +32711,7 @@ METHOD	tx	(Ljava/util/function/BooleanSupplier;)V	a	method_21308
 METHOD	tx	(Laxm;Lacu$a;)V	b	method_21309
 METHOD	tx	()Ljava/util/Map;	d	method_21310
 METHOD	tx	()Ljava/util/Map;	e	method_21311
-CLASS	tx$1	net/minecraft/class_4452$1
+CLASS	tx$1	net/minecraft/class_4453$1
 FIELD	tx$1	Ltx;	a	field_21873
 METHOD	tx$1	(Lacu$a;)Z	a	method_21312
 CLASS	tz	net/minecraft/class_2100
@@ -32720,7 +32720,7 @@ FIELD	tz	Lub;	b	field_8898
 METHOD	tz	(Lio/netty/channel/ChannelHandlerContext;Lio/netty/buffer/ByteBuf;)V	a	method_8140
 METHOD	tz	(Ljava/lang/String;)Lio/netty/buffer/ByteBuf;	a	method_8141
 METHOD	tz	(Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V	channelRead	channelRead
-CLASS	u	net/minecraft/class_3357
+CLASS	u	net/minecraft/class_3358
 FIELD	u	Lij;	a	field_16474
 FIELD	u	Lij;	b	field_16475
 FIELD	u	Late;	c	field_16476
@@ -32871,7 +32871,7 @@ FIELD	ue$a	Lue$a;	g	field_8967
 FIELD	ue$a	[Lue$a;	h	field_8968
 METHOD	ue$a	(Ljava/lang/String;)Lue$a;	valueOf	valueOf
 METHOD	ue$a	()[Lue$a;	values	values
-CLASS	uf	net/minecraft/class_4453
+CLASS	uf	net/minecraft/class_4454
 FIELD	uf	Lij;	a	field_21881
 FIELD	uf	Lnet/minecraft/server/MinecraftServer;	b	field_21882
 FIELD	uf	Lhw;	c	field_21883
@@ -32899,7 +32899,7 @@ METHOD	uk	(Ljava/io/File;ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Lj
 METHOD	uk	(Ljava/io/File;Ljava/lang/String;)Z	a	method_13885
 METHOD	uk	()V	close	close
 METHOD	uk	(Ljava/lang/String;)Ljava/io/File;	e	method_13886
-CLASS	ul	net/minecraft/class_4454
+CLASS	ul	net/minecraft/class_4455
 METHOD	ul	()Ljava/lang/String;	a	method_5899
 METHOD	ul	(Lum;)Ljava/util/Set;	a	method_21327
 METHOD	ul	(Lum;Ljava/lang/String;ILjava/util/function/Predicate;)Ljava/util/Collection;	a	method_21328
@@ -32907,7 +32907,7 @@ METHOD	ul	(Lum;Lpc;)Ljava/io/InputStream;	a	method_5897
 METHOD	ul	(Lup;)Ljava/lang/Object;	a	method_21329
 METHOD	ul	(Ljava/lang/String;)Ljava/io/InputStream;	b	method_21330
 METHOD	ul	(Lum;Lpc;)Z	b	method_5900
-CLASS	um	net/minecraft/class_4455
+CLASS	um	net/minecraft/class_4456
 FIELD	um	Lum;	a	field_21886
 FIELD	um	Lum;	b	field_21887
 FIELD	um	Ljava/lang/String;	c	field_21888
@@ -32916,7 +32916,7 @@ METHOD	um	()Ljava/lang/String;	a	method_21331
 METHOD	um	(Ljava/lang/String;)Lum;	valueOf	valueOf
 METHOD	um	()[Lum;	values	values
 CLASS	un	net/minecraft/class_1656
-CLASS	uo	net/minecraft/class_4456
+CLASS	uo	net/minecraft/class_4457
 FIELD	uo	Ljava/nio/file/Path;	a	field_21890
 FIELD	uo	Ljava/lang/Class;	b	field_21891
 FIELD	uo	Ljava/util/Set;	c	field_21892
@@ -32925,25 +32925,25 @@ METHOD	uo	(ILjava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Ljava/util/f
 METHOD	uo	(Ljava/lang/String;)Ljava/io/InputStream;	a	method_21333
 METHOD	uo	(Lum;Lpc;)Ljava/io/InputStream;	c	method_21334
 METHOD	uo	()V	close	close
-CLASS	up	net/minecraft/class_4457
+CLASS	up	net/minecraft/class_4458
 METHOD	up	()Ljava/lang/String;	a	method_5956
 METHOD	up	(Lcom/google/gson/JsonObject;)Ljava/lang/Object;	a	method_21335
-CLASS	uq	net/minecraft/class_4458
+CLASS	uq	net/minecraft/class_4459
 FIELD	uq	Lur;	a	field_21894
 FIELD	uq	Lij;	b	field_21895
 FIELD	uq	I	c	field_21896
 METHOD	uq	()Lij;	a	method_21336
 METHOD	uq	()I	b	method_21337
-CLASS	ur	net/minecraft/class_4459
+CLASS	ur	net/minecraft/class_4460
 METHOD	ur	(Lcom/google/gson/JsonObject;)Luq;	b	method_21338
-CLASS	uv	net/minecraft/class_4460
+CLASS	uv	net/minecraft/class_4461
 FIELD	uv	Ljava/io/FileFilter;	a	field_21897
 FIELD	uv	Ljava/io/File;	b	field_21898
 METHOD	uv	(Ljava/io/File;)Ljava/util/function/Supplier;	a	method_21339
 METHOD	uv	(Ljava/io/File;)Lul;	b	method_21340
 METHOD	uv	(Ljava/io/File;)Lul;	c	method_21341
 METHOD	uv	(Ljava/io/File;)Z	d	method_21342
-CLASS	uw	net/minecraft/class_4461
+CLASS	uw	net/minecraft/class_4462
 FIELD	uw	Luw;	a	field_21899
 FIELD	uw	Luw;	b	field_21900
 FIELD	uw	Luw;	c	field_21901
@@ -32956,7 +32956,7 @@ METHOD	uw	()Lij;	b	method_21345
 METHOD	uw	()Lij;	c	method_21346
 METHOD	uw	(Ljava/lang/String;)Luw;	valueOf	valueOf
 METHOD	uw	()[Luw;	values	values
-CLASS	ux	net/minecraft/class_4462
+CLASS	ux	net/minecraft/class_4463
 FIELD	ux	Ljava/util/Set;	a	field_21905
 FIELD	ux	Ljava/util/Map;	b	field_21906
 FIELD	ux	Ljava/util/List;	c	field_21907
@@ -32970,12 +32970,12 @@ METHOD	ux	()Ljava/util/Collection;	b	method_21352
 METHOD	ux	()Ljava/util/Collection;	c	method_21353
 METHOD	ux	()Ljava/util/Collection;	d	method_21354
 METHOD	ux	()V	e	method_21355
-CLASS	uy	net/minecraft/class_4463
+CLASS	uy	net/minecraft/class_4464
 METHOD	uy	(Ljava/util/Map;Lva$b;)V	a	method_21356
-CLASS	uz	net/minecraft/class_4464
+CLASS	uz	net/minecraft/class_4465
 FIELD	uz	Luo;	a	field_21909
 METHOD	uz	()Lul;	a	method_21357
-CLASS	v	net/minecraft/class_3358
+CLASS	v	net/minecraft/class_3359
 FIELD	v	Lv;	a	field_16484
 FIELD	v	Lv;	b	field_16485
 FIELD	v	Lv;	c	field_16486
@@ -32989,7 +32989,7 @@ METHOD	v	()I	b	method_15026
 METHOD	v	()La;	c	method_15027
 METHOD	v	(Ljava/lang/String;)Lv;	valueOf	valueOf
 METHOD	v	()[Lv;	values	values
-CLASS	va	net/minecraft/class_4465
+CLASS	va	net/minecraft/class_4466
 FIELD	va	Lorg/apache/logging/log4j/Logger;	a	field_21910
 FIELD	va	Luq;	b	field_21911
 FIELD	va	Ljava/lang/String;	c	field_21912
@@ -33013,7 +33013,7 @@ METHOD	va	()Z	f	method_21366
 METHOD	va	()Z	g	method_21367
 METHOD	va	()Lva$a;	h	method_21368
 METHOD	va	()I	hashCode	hashCode
-CLASS	va$a	net/minecraft/class_4465$class_4466
+CLASS	va$a	net/minecraft/class_4466$class_4467
 FIELD	va$a	Lva$a;	a	field_21920
 FIELD	va$a	Lva$a;	b	field_21921
 FIELD	va$a	[Lva$a;	c	field_21922
@@ -33021,7 +33021,7 @@ METHOD	va$a	()Lva$a;	a	method_21369
 METHOD	va$a	(Ljava/util/List;Ljava/lang/Object;Ljava/util/function/Function;Z)I	a	method_21370
 METHOD	va$a	(Ljava/lang/String;)Lva$a;	valueOf	valueOf
 METHOD	va$a	()[Lva$a;	values	values
-CLASS	va$b	net/minecraft/class_4465$class_4467
+CLASS	va$b	net/minecraft/class_4466$class_4468
 METHOD	va$b	(Ljava/lang/String;ZLjava/util/function/Supplier;Lul;Luq;Lva$a;)Lva;	create	create
 CLASS	vc	net/minecraft/class_1646
 FIELD	vc	Ljava/util/List;	a	field_6609
@@ -33055,7 +33055,7 @@ METHOD	vf	(Lpc;)Lve;	a	method_5893
 METHOD	vf	(Lpc;)Ljava/util/List;	b	method_5894
 CLASS	vg	net/minecraft/class_286
 METHOD	vg	(Lvf;)V	a	method_5895
-CLASS	vh	net/minecraft/class_4468
+CLASS	vh	net/minecraft/class_4469
 FIELD	vh	Lorg/apache/logging/log4j/Logger;	a	field_21923
 FIELD	vh	Ljava/util/Map;	b	field_21924
 FIELD	vh	Ljava/util/List;	c	field_21925
@@ -33066,7 +33066,7 @@ METHOD	vh	()V	b	method_21374
 METHOD	vh	(Lvg;)Ljava/lang/String;	b	method_21375
 METHOD	vh	()V	c	method_21376
 METHOD	vh	()V	d	method_21377
-CLASS	vi	net/minecraft/class_4469
+CLASS	vi	net/minecraft/class_4470
 FIELD	vi	Ljava/util/concurrent/Executor;	a	field_21928
 FIELD	vi	Lorg/apache/logging/log4j/Logger;	b	field_21929
 FIELD	vi	Ljava/lang/String;	c	field_21930
@@ -33348,7 +33348,7 @@ METHOD	vz	(Ljava/lang/String;)V	a	method_2209
 METHOD	vz	(S)V	a	method_2210
 METHOD	vz	([B)V	a	method_2211
 METHOD	vz	()V	b	method_2212
-CLASS	w	net/minecraft/class_4470
+CLASS	w	net/minecraft/class_4471
 FIELD	w	Lw;	AND	AND
 FIELD	w	Lw;	OR	field_21947
 METHOD	w	(Ljava/util/Collection;)[[Ljava/lang/String;	createRequirements	createRequirements
@@ -34135,7 +34135,7 @@ FIELD	wk	[Lwk;	m	field_9105
 METHOD	wk	()Ljava/lang/String;	a	method_8382
 METHOD	wk	(Ljava/lang/String;)Lwk;	valueOf	valueOf
 METHOD	wk	()[Lwk;	values	values
-CLASS	wm	net/minecraft/class_4471
+CLASS	wm	net/minecraft/class_4472
 FIELD	wm	Ljava/util/Set;	a	field_22062
 FIELD	wm	Ljava/util/Set;	b	field_22063
 FIELD	wm	Z	c	field_22064
@@ -34161,7 +34161,7 @@ METHOD	wm	(Lavk;)Z	d	method_21407
 METHOD	wm	(Z)V	d	method_21408
 METHOD	wm	(Lavk;)V	e	method_21409
 METHOD	wm	(Lavk;)V	f	method_21410
-CLASS	wn	net/minecraft/class_3356
+CLASS	wn	net/minecraft/class_3357
 FIELD	wn	Lorg/apache/logging/log4j/Logger;	g	field_16473
 FIELD	wn	Lavl;	h	field_22068
 METHOD	wn	(Lgy;)V	a	method_14994
@@ -34186,7 +34186,7 @@ METHOD	wo	()Ljava/lang/String;	b	method_21417
 METHOD	wo	(Lwp;)Lpc;	b	method_21418
 METHOD	wo	()V	c	method_8277
 METHOD	wo	()Ljava/util/Set;	d	method_8276
-CLASS	wp	net/minecraft/class_4472
+CLASS	wp	net/minecraft/class_4473
 FIELD	wp	Lwq;	o	field_22069
 FIELD	wp	Ljava/lang/Object;	p	field_22070
 FIELD	wp	Lwr;	q	field_22071
@@ -34198,7 +34198,7 @@ METHOD	wp	()Ljava/lang/Object;	b	method_21423
 METHOD	wp	(Ljava/lang/Object;)Z	equals	equals
 METHOD	wp	()I	hashCode	hashCode
 METHOD	wp	()Ljava/lang/String;	toString	toString
-CLASS	wq	net/minecraft/class_4473
+CLASS	wq	net/minecraft/class_4474
 FIELD	wq	Ljava/text/DecimalFormat;	DECIMAL_FORMAT	DECIMAL_FORMAT
 FIELD	wq	Lwq;	DEFAULT	DEFAULT
 FIELD	wq	Lwq;	DISTANCE	DISTANCE
@@ -34209,7 +34209,7 @@ METHOD	wq	(Ljava/text/DecimalFormat;)V	lambda$static$0	lambda$static$0
 METHOD	wq	(I)Ljava/lang/String;	lambda$static$1	lambda$static$1
 METHOD	wq	(I)Ljava/lang/String;	lambda$static$2	lambda$static$2
 METHOD	wq	(I)Ljava/lang/String;	lambda$static$3	lambda$static$3
-CLASS	wr	net/minecraft/class_4474
+CLASS	wr	net/minecraft/class_4475
 FIELD	wr	Lfc;	a	field_22072
 FIELD	wr	Ljava/util/Map;	b	field_22073
 METHOD	wr	()Lfc;	a	method_21424
@@ -34297,7 +34297,7 @@ METHOD	wt	(Laog;Lwp;I)V	a	method_8300
 METHOD	wt	(Lwp;)I	a	method_21434
 METHOD	wt	(Lwr;Ljava/lang/Object;)I	a	method_21435
 METHOD	wt	(Laog;Lwp;I)V	b	method_8302
-CLASS	wv	net/minecraft/class_4475
+CLASS	wv	net/minecraft/class_4476
 FIELD	wv	Lwz;	A	field_22142
 FIELD	wv	Lwz;	B	field_22143
 FIELD	wv	Lwz;	C	field_22144
@@ -34345,11 +34345,11 @@ METHOD	wv	(Lxa;)V	a	method_21439
 METHOD	wv	()I	b	method_21440
 METHOD	wv	(Lpc;)Z	b	method_21441
 METHOD	wv	()Lxa;	c	method_21442
-CLASS	wv$a	net/minecraft/class_4475$class_4476
+CLASS	wv$a	net/minecraft/class_4476$class_4477
 FIELD	wv$a	I	a	field_22182
 FIELD	wv$a	Lwz;	b	field_22183
 METHOD	wv$a	(Lbcs;)Z	a	method_21443
-CLASS	ww	net/minecraft/class_4477
+CLASS	ww	net/minecraft/class_4478
 FIELD	ww	Lwz;	a	field_22184
 FIELD	ww	Lwz;	b	field_22185
 FIELD	ww	Lxa;	c	field_22186
@@ -34360,11 +34360,11 @@ METHOD	ww	(Lxa;)V	a	method_21446
 METHOD	ww	()I	b	method_21447
 METHOD	ww	(Lpc;)Z	b	method_21448
 METHOD	ww	()Lxa;	c	method_21449
-CLASS	ww$a	net/minecraft/class_4477$class_4478
+CLASS	ww$a	net/minecraft/class_4478$class_4479
 FIELD	ww$a	I	a	field_22188
 FIELD	ww$a	Lwz;	b	field_22189
 METHOD	ww$a	(Lbyv;)Z	a	method_21450
-CLASS	wx	net/minecraft/class_4479
+CLASS	wx	net/minecraft/class_4480
 FIELD	wx	Lwz;	A	field_22190
 FIELD	wx	Lwz;	B	field_22191
 FIELD	wx	Lwz;	C	field_22192
@@ -34404,15 +34404,15 @@ METHOD	wx	(Lxa;)V	a	method_21454
 METHOD	wx	()I	b	method_21455
 METHOD	wx	(Lpc;)Z	b	method_21456
 METHOD	wx	()Lxa;	c	method_21457
-CLASS	wx$a	net/minecraft/class_4479$class_4480
+CLASS	wx$a	net/minecraft/class_4480$class_4481
 FIELD	wx$a	I	a	field_22222
 FIELD	wx$a	Lwz;	b	field_22223
 METHOD	wx$a	(Lata;)Z	a	method_21458
-CLASS	wy	net/minecraft/class_4481
+CLASS	wy	net/minecraft/class_4482
 FIELD	wy	Lfc;	a	field_22224
 METHOD	wy	(Lhy;)V	a	method_21459
 METHOD	wy	(Lhy;)V	b	method_21460
-CLASS	wz	net/minecraft/class_4482
+CLASS	wz	net/minecraft/class_4483
 FIELD	wz	Lpc;	a	field_22225
 FIELD	wz	Ljava/util/Set;	b	field_22226
 FIELD	wz	Ljava/util/Collection;	c	field_22227
@@ -34422,7 +34422,7 @@ METHOD	wz	(Ljava/util/Random;)Ljava/lang/Object;	a	method_21463
 METHOD	wz	(Ljava/util/function/Function;)Lcom/google/gson/JsonObject;	a	method_21464
 METHOD	wz	()Ljava/util/Collection;	b	method_21465
 METHOD	wz	()Lpc;	c	method_21466
-CLASS	wz$a	net/minecraft/class_4482$class_4483
+CLASS	wz$a	net/minecraft/class_4483$class_4484
 FIELD	wz$a	Ljava/util/Set;	a	field_22228
 FIELD	wz$a	Z	b	field_22229
 METHOD	wz$a	()Lwz$a;	a	method_21467
@@ -34436,18 +34436,18 @@ METHOD	wz$a	(Lwz;)Lwz$a;	a	method_21474
 METHOD	wz$a	(Z)Lwz$a;	a	method_21475
 METHOD	wz$a	([Ljava/lang/Object;)Lwz$a;	a	method_21476
 METHOD	wz$a	(Lpc;)Lwz;	b	method_21477
-CLASS	wz$b	net/minecraft/class_4482$class_4484
+CLASS	wz$b	net/minecraft/class_4483$class_4485
 METHOD	wz$b	(Lcom/google/gson/JsonArray;Ljava/util/function/Function;)V	a	method_21478
 METHOD	wz$b	(Ljava/util/Collection;)V	a	method_21479
 METHOD	wz$b	(Ljava/util/function/Function;)Z	a	method_21480
-CLASS	wz$c	net/minecraft/class_4482$class_4485
+CLASS	wz$c	net/minecraft/class_4483$class_4486
 FIELD	wz$c	Lpc;	a	field_22230
 FIELD	wz$c	Lwz;	b	field_22231
 METHOD	wz$c	()Lpc;	a	method_21481
-CLASS	wz$d	net/minecraft/class_4482$class_4486
+CLASS	wz$d	net/minecraft/class_4483$class_4487
 FIELD	wz$d	Ljava/util/Collection;	a	field_22232
 METHOD	wz$d	()Ljava/util/Collection;	a	method_21482
-CLASS	x	net/minecraft/class_3361
+CLASS	x	net/minecraft/class_3362
 FIELD	x	Ll;	a	field_16492
 FIELD	x	Lx;	b	field_16493
 FIELD	x	Lx;	c	field_16494
@@ -34472,7 +34472,7 @@ METHOD	x	()V	b	method_15036
 METHOD	x	()Lx;	c	method_15037
 METHOD	x	()Lx;	d	method_15038
 METHOD	x	()V	e	method_15039
-CLASS	xa	net/minecraft/class_4487
+CLASS	xa	net/minecraft/class_4488
 FIELD	xa	Lorg/apache/logging/log4j/Logger;	a	field_22233
 FIELD	xa	Lcom/google/gson/Gson;	b	field_22234
 FIELD	xa	I	c	field_22235
@@ -34491,7 +34491,7 @@ METHOD	xa	(Lwz;)V	a	method_21488
 METHOD	xa	()V	b	method_21489
 METHOD	xa	(Lpc;)Lwz;	b	method_21490
 METHOD	xa	()Ljava/util/Map;	c	method_21491
-CLASS	xb	net/minecraft/class_4488
+CLASS	xb	net/minecraft/class_4489
 FIELD	xb	Lwy;	a	field_22242
 FIELD	xb	Lwy;	b	field_22243
 FIELD	xb	Lwy;	c	field_22244
@@ -34786,13 +34786,13 @@ METHOD	xs	(I)V	a	method_2364
 METHOD	xs	(Lij;)V	a	method_21524
 METHOD	xs	(Lij;)V	b	method_21525
 METHOD	xs	(Lij;)V	c	method_21526
-CLASS	xt	net/minecraft/class_4489
+CLASS	xt	net/minecraft/class_4490
 FIELD	xt	Ljava/util/List;	a	field_22252
 FIELD	xt	Ljava/util/Iterator;	b	field_22253
 METHOD	xt	()Ljava/util/stream/Stream;	a	method_21527
 METHOD	xt	(Lxt;)Ljava/util/List;	a	method_21528
 METHOD	xt	(Lxt;)Ljava/util/Iterator;	b	method_21529
-CLASS	xt$1	net/minecraft/class_4489$1
+CLASS	xt$1	net/minecraft/class_4490$1
 FIELD	xt$1	Lxt;	a	field_22254
 FIELD	xt$1	I	b	field_22255
 METHOD	xt$1	(Ljava/util/function/Consumer;)Z	tryAdvance	tryAdvance
@@ -34850,24 +34850,24 @@ METHOD	xz	(Ljava/lang/String;)Ljava/lang/String;	s	method_21552
 METHOD	xz	(Ljava/lang/String;)Ljava/lang/String;	t	method_21553
 CLASS	xz$1	net/minecraft/class_2935$1
 CLASS	xz$2	net/minecraft/class_2935$2
-CLASS	y	net/minecraft/class_3362
+CLASS	y	net/minecraft/class_3363
 FIELD	y	Lpc;	a	field_16504
 METHOD	y	()Ljava/lang/String;	toString	toString
-CLASS	ya	net/minecraft/class_4490
+CLASS	ya	net/minecraft/class_4491
 FIELD	ya	Ljava/lang/String;	a	field_22262
 FIELD	ya	Lcom/mojang/datafixers/DSL$TypeReference;	b	field_22263
 METHOD	ya	(Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_21554
 METHOD	ya	(Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_21555
 METHOD	ya	(Ljava/lang/String;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;)Lcom/mojang/datafixers/TypeRewriteRule;	a	method_21556
 METHOD	ya	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yb	net/minecraft/class_4491
+CLASS	yb	net/minecraft/class_4492
 FIELD	yb	Ljava/util/Map;	a	field_22264
 METHOD	yb	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21557
 METHOD	yb	(Lcom/mojang/datafixers/Dynamic;Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_21558
 METHOD	yb	(Lcom/mojang/datafixers/Dynamic;Ljava/lang/String;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21559
 METHOD	yb	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21560
 METHOD	yb	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yc	net/minecraft/class_3359
+CLASS	yc	net/minecraft/class_3360
 METHOD	yc	()Ljava/lang/IllegalStateException;	a	method_21561
 METHOD	yc	(Lcom/mojang/datafixers/Dynamic;)Ljava/lang/Integer;	a	method_21562
 METHOD	yc	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21563
@@ -34875,26 +34875,26 @@ METHOD	yc	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function
 METHOD	yc	(Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/types/templates/List$ListType;)Lcom/mojang/datafixers/TypeRewriteRule;	a	method_21565
 METHOD	yc	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_21566
 METHOD	yc	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yd	net/minecraft/class_3360
+CLASS	yd	net/minecraft/class_3361
 METHOD	yd	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21567
 METHOD	yd	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	ye	net/minecraft/class_4492
+CLASS	ye	net/minecraft/class_4493
 FIELD	ye	Ljava/util/Map;	a	field_22265
 METHOD	ye	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_21568
 METHOD	ye	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_21569
 METHOD	ye	(Ljava/lang/String;)Ljava/lang/String;	a	method_21570
 METHOD	ye	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yf	net/minecraft/class_4493
+CLASS	yf	net/minecraft/class_4494
 METHOD	yf	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21571
 METHOD	yf	(Ljava/util/stream/Stream;)Ljava/util/stream/Stream;	a	method_21572
 METHOD	yf	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	b	method_21573
 METHOD	yf	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	c	method_21574
 METHOD	yf	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	d	method_21575
 METHOD	yf	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	e	method_21576
-CLASS	yg	net/minecraft/class_4494
+CLASS	yg	net/minecraft/class_4495
 METHOD	yg	()Ljava/lang/IllegalStateException;	a	method_21577
 METHOD	yg	()Ljava/lang/IllegalStateException;	b	method_21578
-CLASS	yh	net/minecraft/class_4495
+CLASS	yh	net/minecraft/class_4496
 METHOD	yh	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21579
 METHOD	yh	(Lcom/mojang/datafixers/Typed;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21580
 METHOD	yh	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
@@ -34905,9 +34905,9 @@ METHOD	yi	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a
 METHOD	yi	(Ljava/lang/String;)Ljava/lang/String;	a	method_21583
 METHOD	yi	(Ljava/util/HashMap;)V	a	method_21584
 METHOD	yi	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yj	net/minecraft/class_4496
+CLASS	yj	net/minecraft/class_4497
 METHOD	yj	()Ljava/lang/IllegalStateException;	a	method_21585
-CLASS	yk	net/minecraft/class_4497
+CLASS	yk	net/minecraft/class_4498
 METHOD	yk	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21586
 CLASS	yl	net/minecraft/class_3119
 METHOD	yl	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21587
@@ -34918,13 +34918,13 @@ METHOD	ym	(Lcom/mojang/datafixers/Dynamic;Ljava/lang/String;)Lcom/mojang/datafix
 CLASS	ym$1	net/minecraft/class_2950$1
 METHOD	ym$1	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lij;	a	method_12914
 METHOD	ym$1	(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;	deserialize	deserialize
-CLASS	yn	net/minecraft/class_4498
+CLASS	yn	net/minecraft/class_4499
 METHOD	yn	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_21590
 METHOD	yn	(Lcom/mojang/datafixers/util/Either;)Ljava/lang/String;	a	method_21591
 METHOD	yn	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_21592
 METHOD	yn	(Ljava/lang/String;)Ljava/lang/String;	a	method_21593
 METHOD	yn	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yo	net/minecraft/class_4499
+CLASS	yo	net/minecraft/class_4500
 FIELD	yo	Ljava/lang/String;	a	field_22266
 METHOD	yo	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21594
 METHOD	yo	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21595
@@ -34933,9 +34933,9 @@ METHOD	yo	(Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function
 METHOD	yo	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_21598
 METHOD	yo	(Ljava/lang/String;)Ljava/lang/String;	a	method_21599
 METHOD	yo	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yo$1	net/minecraft/class_4499$1
+CLASS	yo$1	net/minecraft/class_4500$1
 FIELD	yo$1	Ljava/util/function/Function;	a	field_22267
-CLASS	yp	net/minecraft/class_4500
+CLASS	yp	net/minecraft/class_4501
 FIELD	yp	Lorg/apache/logging/log4j/Logger;	a	field_22268
 FIELD	yp	[Lcom/mojang/datafixers/Dynamic;	b	field_22269
 FIELD	yp	Lit/unimi/dsi/fastutil/objects/Object2IntMap;	c	field_22270
@@ -34948,10 +34948,10 @@ METHOD	yp	(Ljava/lang/String;)Ljava/lang/String;	a	method_21604
 METHOD	yp	(I)Lcom/mojang/datafixers/Dynamic;	b	method_21605
 METHOD	yp	(Lit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;)V	b	method_21606
 METHOD	yp	(Ljava/lang/String;)Lcom/mojang/datafixers/Dynamic;	b	method_21607
-CLASS	yq	net/minecraft/class_4501
+CLASS	yq	net/minecraft/class_4502
 METHOD	yq	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21608
 METHOD	yq	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yr	net/minecraft/class_4502
+CLASS	yr	net/minecraft/class_4503
 FIELD	yr	Lorg/apache/logging/log4j/Logger;	a	field_22272
 FIELD	yr	Ljava/util/BitSet;	b	field_22273
 FIELD	yr	Ljava/util/BitSet;	c	field_22274
@@ -35011,14 +35011,14 @@ METHOD	yr	()Lcom/mojang/datafixers/Dynamic;	q	method_21642
 METHOD	yr	()Lcom/mojang/datafixers/Dynamic;	r	method_21643
 METHOD	yr	()Lcom/mojang/datafixers/Dynamic;	s	method_21644
 METHOD	yr	()Lorg/apache/logging/log4j/Logger;	t	method_21645
-CLASS	yr$1	net/minecraft/class_4502$1
+CLASS	yr$1	net/minecraft/class_4503$1
 FIELD	yr$1	[I	a	field_22293
-CLASS	yr$a	net/minecraft/class_4502$class_4503
+CLASS	yr$a	net/minecraft/class_4503$class_4504
 FIELD	yr$a	[B	a	field_22294
 METHOD	yr$a	(I)Z	a	method_21646
 METHOD	yr$a	(III)I	a	method_21647
 METHOD	yr$a	(I)I	b	method_21648
-CLASS	yr$b	net/minecraft/class_4502$class_4504
+CLASS	yr$b	net/minecraft/class_4503$class_4505
 FIELD	yr$b	Lyr$b;	a	field_22295
 FIELD	yr$b	Lyr$b;	b	field_22296
 FIELD	yr$b	Lyr$b;	c	field_22297
@@ -35032,14 +35032,14 @@ METHOD	yr$b	()Lyr$b$b;	a	method_21649
 METHOD	yr$b	()Lyr$b$a;	b	method_21650
 METHOD	yr$b	(Ljava/lang/String;)Lyr$b;	valueOf	valueOf
 METHOD	yr$b	()[Lyr$b;	values	values
-CLASS	yr$b$a	net/minecraft/class_4502$class_4504$class_4505
+CLASS	yr$b$a	net/minecraft/class_4503$class_4505$class_4506
 FIELD	yr$b$a	Lyr$b$a;	a	field_22304
 FIELD	yr$b$a	Lyr$b$a;	b	field_22305
 FIELD	yr$b$a	Lyr$b$a;	c	field_22306
 FIELD	yr$b$a	[Lyr$b$a;	d	field_22307
 METHOD	yr$b$a	(Ljava/lang/String;)Lyr$b$a;	valueOf	valueOf
 METHOD	yr$b$a	()[Lyr$b$a;	values	values
-CLASS	yr$b$b	net/minecraft/class_4502$class_4504$class_4506
+CLASS	yr$b$b	net/minecraft/class_4503$class_4505$class_4507
 FIELD	yr$b$b	Lyr$b$b;	a	field_22308
 FIELD	yr$b$b	Lyr$b$b;	b	field_22309
 FIELD	yr$b$b	I	c	field_22310
@@ -35047,7 +35047,7 @@ FIELD	yr$b$b	[Lyr$b$b;	d	field_22311
 METHOD	yr$b$b	()I	a	method_21651
 METHOD	yr$b$b	(Ljava/lang/String;)Lyr$b$b;	valueOf	valueOf
 METHOD	yr$b$b	()[Lyr$b$b;	values	values
-CLASS	yr$c	net/minecraft/class_4502$class_4507
+CLASS	yr$c	net/minecraft/class_4503$class_4508
 FIELD	yr$c	I	a	field_22312
 FIELD	yr$c	Lxg;	b	field_22313
 FIELD	yr$c	Lcom/mojang/datafixers/Dynamic;	c	field_22314
@@ -35066,7 +35066,7 @@ METHOD	yr$c	(Lyr$c;)Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;	a	method_21657
 METHOD	yr$c	(I)I	b	method_21658
 METHOD	yr$c	(Ljava/nio/ByteBuffer;)Lyr$a;	b	method_21659
 METHOD	yr$c	(Lyr$c;)Lit/unimi/dsi/fastutil/ints/IntList;	b	method_21660
-CLASS	yr$d	net/minecraft/class_4502$class_4508
+CLASS	yr$d	net/minecraft/class_4503$class_4509
 FIELD	yr$d	I	a	field_22321
 FIELD	yr$d	[Lyr$c;	b	field_22322
 FIELD	yr$d	Lcom/mojang/datafixers/Dynamic;	c	field_22323
@@ -35084,14 +35084,14 @@ METHOD	yr$d	(Lcom/mojang/datafixers/Dynamic;)V	b	method_21668
 METHOD	yr$d	(Ljava/util/stream/Stream;)V	b	method_21669
 METHOD	yr$d	(I)Lcom/mojang/datafixers/Dynamic;	c	method_21670
 METHOD	yr$d	(I)Lyr$c;	d	method_21671
-CLASS	ys	net/minecraft/class_4509
+CLASS	ys	net/minecraft/class_4510
 FIELD	ys	Lcom/google/common/collect/ImmutableMap;	a	field_22327
 METHOD	ys	(Lcom/mojang/datafixers/Dynamic;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21672
 METHOD	ys	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21673
 METHOD	ys	(Lcom/mojang/datafixers/Typed;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21674
 METHOD	ys	(Lcom/mojang/datafixers/Typed;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21675
 METHOD	ys	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yt	net/minecraft/class_4510
+CLASS	yt	net/minecraft/class_4511
 METHOD	yt	()Ljava/lang/IllegalStateException;	a	method_21676
 METHOD	yt	(III)S	a	method_21677
 METHOD	yt	(Lcom/mojang/datafixers/Dynamic;I)Lcom/mojang/datafixers/Dynamic;	a	method_21678
@@ -35099,11 +35099,11 @@ METHOD	yt	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/types/Type;
 METHOD	yt	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21680
 METHOD	yt	(Ljava/util/List;Lcom/mojang/datafixers/Dynamic;Lcom/mojang/datafixers/Dynamic;)V	a	method_21681
 METHOD	yt	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yu	net/minecraft/class_4511
+CLASS	yu	net/minecraft/class_4512
 METHOD	yu	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21682
 CLASS	yv	net/minecraft/class_2937
 METHOD	yv	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21683
-CLASS	yw	net/minecraft/class_4512
+CLASS	yw	net/minecraft/class_4513
 FIELD	yw	Ljava/util/Map;	a	field_22328
 METHOD	yw	(Lcom/mojang/datafixers/Dynamic;)Ljava/lang/Integer;	a	method_21684
 METHOD	yw	(Lcom/mojang/datafixers/Dynamic;Lcom/mojang/datafixers/util/Either;)Lcom/mojang/datafixers/util/Either;	a	method_21685
@@ -35123,29 +35123,29 @@ METHOD	yw	(Ljava/lang/Integer;)Ljava/lang/Integer;	b	method_21698
 METHOD	yw	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	c	method_21699
 METHOD	yw	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	d	method_21700
 METHOD	yw	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	yx	net/minecraft/class_4513
+CLASS	yx	net/minecraft/class_4514
 FIELD	yx	Ljava/util/Map;	a	field_22329
 FIELD	yx	Ljava/util/Map;	b	field_22330
-CLASS	yy	net/minecraft/class_4514
+CLASS	yy	net/minecraft/class_4515
 METHOD	yy	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21701
 METHOD	yy	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21702
 METHOD	yy	(Lcom/mojang/datafixers/Typed;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21703
 METHOD	yy	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
 CLASS	yz	net/minecraft/class_3120
-CLASS	z	net/minecraft/class_3363
+CLASS	z	net/minecraft/class_3364
 FIELD	z	Lpc;	a	field_16505
 FIELD	z	Ljava/util/Map;	b	field_16506
 METHOD	z	(Ltf;Lajq;Lajq;Laeo;)V	a	method_15041
 METHOD	z	()Lpc;	b	method_15042
 METHOD	z	(Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lz$b;	b	method_15043
-CLASS	z$a	net/minecraft/class_3363$class_3364
+CLASS	z$a	net/minecraft/class_3364$class_3365
 FIELD	z$a	Lpm;	a	field_16507
 FIELD	z$a	Ljava/util/Set;	b	field_16508
 METHOD	z$a	()Z	a	method_15044
 METHOD	z$a	(Ls$a;)V	a	method_15046
 METHOD	z$a	(Ltf;Lajq;Lajq;Laeo;)V	a	method_15045
 METHOD	z$a	(Ls$a;)V	b	method_15047
-CLASS	z$b	net/minecraft/class_3363$class_4515
+CLASS	z$b	net/minecraft/class_3364$class_4516
 FIELD	z$b	Lao;	a	field_22331
 FIELD	z$b	Lao;	b	field_22332
 FIELD	z$b	Lao;	c	field_22333
@@ -35173,7 +35173,7 @@ METHOD	ze	(Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a
 METHOD	ze	(Ljava/lang/String;)Ljava/lang/String;	a	method_21716
 METHOD	ze	(Ljava/util/HashMap;)V	a	method_21717
 METHOD	ze	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	zf	net/minecraft/class_4516
+CLASS	zf	net/minecraft/class_4517
 METHOD	zf	(B)B	a	method_21718
 METHOD	zf	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21719
 CLASS	zg	net/minecraft/class_2947
@@ -35192,11 +35192,11 @@ METHOD	zh	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	b	met
 METHOD	zh	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/types/Type;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	b	method_21728
 METHOD	zh	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	b	method_21729
 METHOD	zh	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	zi	net/minecraft/class_4517
+CLASS	zi	net/minecraft/class_4518
 FIELD	zi	Ljava/util/Map;	a	field_22335
 METHOD	zi	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21730
 METHOD	zi	(Ljava/util/HashMap;)V	a	method_21731
-CLASS	zj	net/minecraft/class_4518
+CLASS	zj	net/minecraft/class_4519
 FIELD	zj	Ljava/util/Map;	a	field_22336
 CLASS	zk	net/minecraft/class_2942
 METHOD	zk	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21732
@@ -35204,7 +35204,7 @@ METHOD	zk	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_
 METHOD	zk	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	b	method_21734
 METHOD	zk	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	c	method_21735
 METHOD	zk	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	zl	net/minecraft/class_4519
+CLASS	zl	net/minecraft/class_4520
 FIELD	zl	Ljava/lang/String;	a	field_22337
 METHOD	zl	(Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/DynamicOps;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/util/Pair;)Lcom/mojang/datafixers/util/Pair;	a	method_21736
 METHOD	zl	(Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/DynamicOps;)Ljava/util/function/Function;	a	method_21737
@@ -35228,12 +35228,12 @@ CLASS	zp	net/minecraft/class_2944
 METHOD	zp	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21749
 METHOD	zp	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21750
 METHOD	zp	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	zq	net/minecraft/class_4520
+CLASS	zq	net/minecraft/class_4521
 FIELD	zq	Ljava/util/Map;	a	field_22338
 FIELD	zq	Ljava/util/Map;	b	field_22339
 FIELD	zq	Ljava/util/Map;	c	field_22340
-CLASS	zr	net/minecraft/class_4521
-CLASS	zs	net/minecraft/class_4522
+CLASS	zr	net/minecraft/class_4522
+CLASS	zs	net/minecraft/class_4523
 METHOD	zs	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21751
 METHOD	zs	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	b	method_21752
 CLASS	zt	net/minecraft/class_3125
@@ -35241,12 +35241,12 @@ CLASS	zu	net/minecraft/class_3030
 FIELD	zu	Ljava/util/Random;	a	field_15023
 METHOD	zu	(I)I	a	method_13920
 METHOD	zu	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21753
-CLASS	zv	net/minecraft/class_4523
+CLASS	zv	net/minecraft/class_4524
 METHOD	zv	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21754
 METHOD	zv	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21755
 METHOD	zv	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21756
 METHOD	zv	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	zw	net/minecraft/class_4524
+CLASS	zw	net/minecraft/class_4525
 METHOD	zw	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21757
 METHOD	zw	(Ljava/util/stream/Stream;)Ljava/util/stream/Stream;	a	method_21758
 METHOD	zw	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	b	method_21759
@@ -35257,7 +35257,7 @@ METHOD	zw	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
 CLASS	zx	net/minecraft/class_3126
 METHOD	zx	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21763
 METHOD	zx	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
-CLASS	zy	net/minecraft/class_4525
+CLASS	zy	net/minecraft/class_4526
 METHOD	zy	(Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;	a	method_21764
 METHOD	zy	(Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21765
 METHOD	zy	(Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;	a	method_21766
@@ -35273,4 +35273,4 @@ METHOD	zz	(Ljava/lang/Integer;)Lcom/mojang/datafixers/util/Pair;	a	method_21772
 METHOD	zz	()Lcom/mojang/datafixers/TypeRewriteRule;	makeRule	makeRule
 # INTERMEDIARY-COUNTER field 22342
 # INTERMEDIARY-COUNTER method 21773
-# INTERMEDIARY-COUNTER class 4526
+# INTERMEDIARY-COUNTER class 4527

--- a/matches/1.11.2-1.12.2.match
+++ b/matches/1.11.2-1.12.2.match
@@ -77817,8 +77817,6 @@ c	Lno;	Lqg;
 	f	k;;Ljava/util/Map;	k;;Ljava/util/Map;
 	f	l;;Ljava/lang/String;	l;;Ljava/lang/String;
 	f	m;;[Lno;	m;;[Lqg;
-c	Lnr;	Lm;
-	m	<clinit>()V	<clinit>()V
 c	Lnt;	Lqj;
 	m	<init>(Ljava/lang/String;Lfb;Lnx;)V	<init>(Ljava/lang/String;Lhh;Lqp;)V
 		ma	0	0


### PR DESCRIPTION
Merge when we've found a way for loom to detect if it's using old intermediary or not.