### PR TITLE
temporary fix for unstable intermediaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ file('mappings').eachFile {
 				}
 			}
 
-			create("${mcVer.replace(" ", "")}_timed_mavenJava", MavenPublication) {
+			create("${mcVer.replace(" ", "")}_mavenJava", MavenPublication) {
 				groupId 'net.fabricmc'
 				artifactId "intermediary"
 				version mcVerTimed

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ static def buildTime() {
 	return df.format(new Date())
 }
 
-def build_time = build_time();
+def build_time = buildTime();
 
 def localMappingsPath = "$buildDir/v2Mappings"
 new File(localMappingsPath).mkdirs()

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,14 @@ plugins {
 	id 'maven-publish'
 }
 
+static def buildTime() {
+	def df = new java.text.SimpleDateFormat("yyyyMMddHHmm")
+	df.setTimeZone(TimeZone.getTimeZone("UTC"))
+	return df.format(new Date())
+}
+
+def build_time = build_time();
+
 def localMappingsPath = "$buildDir/v2Mappings"
 new File(localMappingsPath).mkdirs()
 file('mappings').eachFile {
@@ -47,9 +55,15 @@ file('mappings').eachFile {
 	Jar makeV1Jar = makeJar(mcVer, v1MappingFile, false)
 	Jar makeV2Jar = makeJar(mcVer, v2MappingFile, true)
 
+	def mcVerTimed = mcVer + "+" + build_time
+
+	Jar makeV1JarTimed = makeJar(mcVerTimed, v1MappingFile, false)
+	Jar makeV2JarTimed = makeJar(mcVerTimed, v2MappingFile, true)
 
 	build.dependsOn makeV1Jar
 	build.dependsOn makeV2Jar
+	build.dependsOn makeV1JarTimed
+	build.dependsOn makeV2JarTimed
 
 	makeV2Jar.dependsOn conversionTask
 
@@ -64,6 +78,19 @@ file('mappings').eachFile {
 				}
 				artifact(makeV2Jar.archiveFile) {
 					builtBy makeV2Jar
+					classifier = "v2"
+				}
+			}
+
+			create("${mcVer.replace(" ", "")}_timed_mavenJava", MavenPublication) {
+				groupId 'net.fabricmc'
+				artifactId "intermediary"
+				version mcVerTimed
+				artifact(makeV1JarTimed.archiveFile) {
+					builtBy makeV1JarTimed
+				}
+				artifact(makeV2JarTimed.archiveFile) {
+					builtBy makeV2JarTimed
 					classifier = "v2"
 				}
 			}


### PR DESCRIPTION
Maven artefacts changes:
Make "${minecraftVersion}" being unstable
add "${minecraftVersion}+${buildTime}" stable